### PR TITLE
Add optional low-score drive discard marking

### DIFF
--- a/src/app/theme.py
+++ b/src/app/theme.py
@@ -54,6 +54,10 @@ QRadioButton::indicator:hover{border:2px solid #58a6ff}
 QCheckBox{spacing:8px}
 QCheckBox::indicator{width:18px;height:18px;border-radius:4px;border:2px solid #30363d;background:#0d1117}
 QCheckBox::indicator:checked{background:#238636;border-color:#2ea043}
+QCheckBox#autoDiscardToggle{spacing:10px;padding:6px 0}
+QCheckBox#autoDiscardToggle::indicator{width:22px;height:22px;border-radius:11px;border:2px solid #30363d;background:#0d1117}
+QCheckBox#autoDiscardToggle::indicator:checked{border:2px solid #58a6ff;background:qradialgradient(cx:0.5,cy:0.5,radius:0.5,fx:0.5,fy:0.5,stop:0 #58a6ff,stop:0.45 #1f6feb,stop:0.5 #0d1117,stop:1 #0d1117)}
+QCheckBox#autoDiscardToggle::indicator:hover{border:2px solid #58a6ff}
 
 QScrollArea{border:none;background:transparent}
 QScrollBar:vertical{background:#0d1117;width:8px;border-radius:4px}
@@ -92,4 +96,3 @@ def apply_dark_palette(app: QApplication) -> None:
     palette.setColor(QPalette.Highlight, QColor("#1f6feb"))
     palette.setColor(QPalette.HighlightedText, QColor("#ffffff"))
     app.setPalette(palette)
-

--- a/src/app/workers.py
+++ b/src/app/workers.py
@@ -99,9 +99,11 @@ class GamepadScanParseWorkerThread(QThread):
     scan_done = Signal(int, int)
     progress = Signal(int, int, str)
 
-    def __init__(self, total_drives, parent=None):
+    def __init__(self, total_drives, parent=None, auto_discard_grade=None, auto_discard_lock_action="skip"):
         super().__init__(parent)
         self.total_drives = total_drives
+        self.auto_discard_grade = auto_discard_grade
+        self.auto_discard_lock_action = auto_discard_lock_action
         self.scanner = None
 
     def run(self):
@@ -135,6 +137,9 @@ class GamepadScanParseWorkerThread(QThread):
                 progress_callback=lambda current, total, filename: self.progress.emit(current, total, filename),
                 cancel_check=lambda: bool(getattr(self.scanner, "_stopped", False)),
                 scan_done_callback=lambda captured, total: self.scan_done.emit(captured, total),
+                auto_discard_grade=self.auto_discard_grade,
+                auto_discard_lock_action=self.auto_discard_lock_action,
+                config_dir=str(runtime.CONFIG_DIR),
             )
             if int(stats.get("total_count", 0) or 0) != int(self.total_drives):
                 raise RuntimeError("全量扫描未完整结束，流水线解析结果未写入库存。")

--- a/src/features/allocation/execute_page.py
+++ b/src/features/allocation/execute_page.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from PySide6.QtGui import QIntValidator
 from PySide6.QtWidgets import (
     QButtonGroup,
+    QCheckBox,
+    QComboBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -89,6 +91,53 @@ def build_execute_page(window, role_selector_cls, scan_help, drone_help, offline
     total_count_layout.addWidget(window.total_count_edit)
     total_count_layout.addStretch()
     scan_card.layout().addWidget(window.total_count_frame)
+
+    window.auto_discard_frame = QWidget()
+    window.auto_discard_frame.setVisible(False)
+    auto_discard_layout = QVBoxLayout(window.auto_discard_frame)
+    auto_discard_layout.setContentsMargins(28, 0, 0, 4)
+    auto_discard_layout.setSpacing(4)
+    auto_discard_row = QHBoxLayout()
+    auto_discard_row.setSpacing(8)
+    window.auto_discard_checkbox = QCheckBox("扫描后顺便标记弃置")
+    window.auto_discard_checkbox.setObjectName("autoDiscardToggle")
+    auto_discard_row.addWidget(window.auto_discard_checkbox)
+    auto_discard_row.addWidget(QLabel("最高评分低于:"))
+    window.auto_discard_grade_combo = QComboBox()
+    for grade in ["ACE", "SSS", "SS", "S", "A", "B", "C", "D"]:
+        window.auto_discard_grade_combo.addItem(grade, grade)
+    window.auto_discard_grade_combo.setCurrentText("A")
+    window.auto_discard_grade_combo.setMaximumWidth(90)
+    auto_discard_row.addWidget(window.auto_discard_grade_combo)
+    window.auto_discard_grade_help = QPushButton("?")
+    window.auto_discard_grade_help.setObjectName("btnHelp")
+    window.auto_discard_grade_help.clicked.connect(
+        lambda _checked=False: show_help(
+            window,
+            "自动弃置评分说明",
+            "扫描完库存后，会使用【所有角色权重】（不仅是第二步选择要配装的角色）计算每个驱动的最高评分等级。\n\n"
+            "评分等级低于你选择等级的驱动会被打上弃置；等于所选等级的驱动不会被弃置。\n\n"
+            "例如:\n"
+            "- 选 A: 只标 B/C/D\n"
+            "- 选 S: 只标 A/B/C/D\n"
+            "- 选 SS: 只标 S/A/B/C/D",
+        )
+    )
+    auto_discard_row.addWidget(window.auto_discard_grade_help)
+    auto_discard_row.addStretch()
+    auto_discard_layout.addLayout(auto_discard_row)
+
+    auto_discard_lock_row = QHBoxLayout()
+    auto_discard_lock_row.setSpacing(8)
+    auto_discard_lock_row.addWidget(QLabel("遇到锁定驱动:"))
+    window.auto_discard_lock_action_combo = QComboBox()
+    window.auto_discard_lock_action_combo.addItem("跳过", "skip")
+    window.auto_discard_lock_action_combo.addItem("自动解锁并弃置", "unlock")
+    window.auto_discard_lock_action_combo.setMaximumWidth(150)
+    auto_discard_lock_row.addWidget(window.auto_discard_lock_action_combo)
+    auto_discard_lock_row.addStretch()
+    auto_discard_layout.addLayout(auto_discard_lock_row)
+    scan_card.layout().addWidget(window.auto_discard_frame)
 
     window.drone_frame = QWidget()
     window.drone_frame.setVisible(False)

--- a/src/features/scanning/controller.py
+++ b/src/features/scanning/controller.py
@@ -63,6 +63,8 @@ def _on_scan_change(self,id):
     if hasattr(self,"offline_frame"):
         self.offline_frame.setVisible(id==3)
     self.total_count_frame.setVisible(id==1)
+    if hasattr(self,"auto_discard_frame"):
+        self.auto_discard_frame.setVisible(id==1)
     self.drone_frame.setVisible(id==2)
 
 def _on_priority_changed(self):
@@ -123,6 +125,15 @@ def _do_exec(self):
     self._pending_strat=strat; self._pending_sel=sel; self._pending_cs=cs; self._pending_tape_main_filters=tmf; self._pending_crit_priority_modes=cpm; self._pending_crit_rate_caps=crc; self._pending_set_effect_modes=sem; self._pending_priority_groups=pg
     self._pending_archive_paths=[]
     self._pending_parse_only=parse_only
+    auto_discard_grade=None
+    auto_discard_lock_action="skip"
+    if sm=="1" and getattr(self,"auto_discard_checkbox",None) and self.auto_discard_checkbox.isChecked():
+        auto_discard_grade=self.auto_discard_grade_combo.currentText() if hasattr(self,"auto_discard_grade_combo") else "A"
+        auto_discard_lock_action=(
+            self.auto_discard_lock_action_combo.currentData()
+            if hasattr(self,"auto_discard_lock_action_combo")
+            else "skip"
+        )
 
     if sm=="3":
         scope={"full":"full","incremental":"incremental","all":"all"}.get(offline_scope,"incremental")
@@ -131,7 +142,11 @@ def _do_exec(self):
         drone_mode=pending_drone_mode or ("auto" if self.drone_group.checkedId()==1 else "semi")
         self._start_scan(drone_mode)
     elif sm=="1":
-        self._start_gamepad_scan(total_drives)
+        self._start_gamepad_scan(
+            total_drives,
+            auto_discard_grade=auto_discard_grade,
+            auto_discard_lock_action=auto_discard_lock_action,
+        )
     else:
         self._worker=WorkerThread(target=lambda:self._run_allocation(strat,sel,cs,tmf,cpm,sem,pg,crc),parent=self)
         self._worker.result_ready.connect(self._on_done); self._worker.error.connect(self._on_exec_error); self._worker.start()
@@ -242,6 +257,8 @@ def _on_vision_done(self,stats):
     failed_count=int(stats.get("failed_count",0) or 0)
     duplicate_count=int(stats.get("duplicate_count",0) or 0)+int(post.get("probe_duplicates",0) or 0)
     summary=f"解析成功 {success_count} 张，解析失败 {failed_count} 张，过滤重复 {duplicate_count} 张。"
+    if stats.get("auto_discard_grade"):
+        summary += f"\n低于 {stats['auto_discard_grade']} 的驱动：目标 {int(stats.get('discard_target_count',0) or 0)} 个，已标记 {int(stats.get('discard_marked_count',0) or 0)} 个。"
     details=[]
     if post.get("moved_failed"):
         details.append(f"失败截图已移动到 failed 文件夹 {post['moved_failed']} 张。")
@@ -291,7 +308,7 @@ def _start_scan(self,drone_mode):
     self.btn_run.setText("⏳  扫描中... (F12 停止)")
     self._scan_worker.start()
 
-def _start_gamepad_scan(self,total_drives):
+def _start_gamepad_scan(self,total_drives, auto_discard_grade=None, auto_discard_lock_action="skip"):
     self._replace_inventory_on_next_parse=True
     self._pending_scan_mode="gamepad"
     self._pending_parse_scope="full"
@@ -299,15 +316,27 @@ def _start_gamepad_scan(self,total_drives):
     self._pending_probe_duplicate_count=0
     self._gamepad_parse_progress=(0,total_drives,"")
     self._gamepad_pipeline_finished=False
+    discard_hint = ""
+    if auto_discard_grade:
+        discard_hint = (
+            f"\n\n已启用自动标记弃置：扫描解析后会标记最高评分低于 {auto_discard_grade} 的驱动。"
+            "\n扫描开始后不要切换排序、筛选、滚动或手动操作背包。"
+        )
     QMessageBox.information(
         self,
         "全量扫描准备",
         "点击 OK 后程序会最小化并准备开始全量扫描。\n\n"
         "请切换至游戏的驱动仓库页面，并确保当前选中第一排第一个驱动。\n"
         "程序会在短暂倒计时后接管虚拟手柄进行遍历截图。"
+        + discard_hint
     )
     self.showMinimized()
-    self._gamepad_worker=GamepadScanParseWorkerThread(total_drives=total_drives,parent=self)
+    self._gamepad_worker=GamepadScanParseWorkerThread(
+        total_drives=total_drives,
+        parent=self,
+        auto_discard_grade=auto_discard_grade,
+        auto_discard_lock_action=auto_discard_lock_action,
+    )
     self._gamepad_worker.scan_done.connect(self._on_gamepad_scan_done)
     self._gamepad_worker.progress.connect(self._on_gamepad_parse_progress)
     self._gamepad_worker.processing_done.connect(self._on_gamepad_pipeline_done)

--- a/src/features/scanning/streaming_pipeline.py
+++ b/src/features/scanning/streaming_pipeline.py
@@ -10,11 +10,95 @@ import time
 from pathlib import Path
 from typing import Callable
 
+import cv2
+import numpy as np
+
+from src.models.equipment import Drive
+from src.optimizer.scoring import ScoringEngine
+from src.scanner.window_capture import crop_window_border_from_image
+from src.utils.image_io import imread_unicode
 from src.utils.logger import logger
 from src.utils.perf import log_perf
 
 
 _STOP = object()
+GRADE_ORDER = ["ACE", "SSS", "SS", "S", "A", "B", "C", "D"]
+
+
+def _lock_icon_mask_is_locked(mask: np.ndarray) -> bool:
+    if mask.size == 0:
+        return False
+    height, width = mask.shape[:2]
+    if height < 8 or width < 8:
+        return False
+    top = mask[: max(1, height // 2)]
+    top_left = top[:, : max(1, width // 2)].mean()
+    top_right = top[:, width // 2 :].mean()
+    return bool(top_left > 0.48 and top_right > 0.48)
+
+
+def _drive_screenshot_is_locked(image_path: str) -> bool:
+    try:
+        img = imread_unicode(image_path)
+        if img is None:
+            return False
+        img = crop_window_border_from_image(img)
+        height, width = img.shape[:2]
+        if height < 100 or width < 100:
+            return False
+
+        region = img[
+            int(height * 0.06) : int(height * 0.30),
+            int(width * 0.55) : int(width * 0.98),
+        ]
+        if region.size == 0:
+            return False
+
+        gray = region.mean(axis=2)
+        spread = region.max(axis=2) - region.min(axis=2)
+        mask = ((gray > 70) & (spread < 75)).astype("uint8")
+        count, labels, stats, _ = cv2.connectedComponentsWithStats(mask, 8)
+
+        candidate = None
+        for label in range(1, count):
+            x, y, w, h, area = stats[label]
+            if 20 <= area <= 3000 and 8 <= w <= 100 and 8 <= h <= 100 and 0.4 <= (w / h) <= 1.8:
+                if candidate is None or x + w > candidate[0]:
+                    candidate = (x + w, label, x, y, w, h)
+
+        if candidate is None:
+            return False
+        _, label, x, y, w, h = candidate
+        return _lock_icon_mask_is_locked(labels[y : y + h, x : x + w] == label)
+    except Exception as exc:
+        logger.debug(f"锁定图标检测失败，按未锁处理: {image_path} | {exc}")
+        return False
+
+
+def _discard_target_indexes(
+    processor,
+    parsed_items: list[tuple[int, object, bool]],
+    grade: str,
+    config_dir,
+    lock_action: str = "skip",
+) -> list[int]:
+    if not grade or grade not in GRADE_ORDER or not getattr(processor, "inventory", None):
+        return []
+    scoring = ScoringEngine(str(config_dir or "config"))
+    if not scoring.roles_db:
+        return []
+    scoring.evaluate_global_inventory(processor.inventory)
+    threshold_rank = GRADE_ORDER.index(grade)
+    targets = []
+    for index, item, locked in parsed_items:
+        if locked and lock_action != "unlock":
+            continue
+        if not isinstance(item, Drive):
+            continue
+        item_grade = scoring.get_grade_tag(getattr(item, "max_score", 0.0), getattr(item, "area", 1))
+        if item_grade in GRADE_ORDER and GRADE_ORDER.index(item_grade) > threshold_rank:
+            targets.append(index)
+    return targets
 
 
 def run_streaming_scan_parse(
@@ -24,6 +108,9 @@ def run_streaming_scan_parse(
     progress_callback: Callable[[int, int, str], None] | None = None,
     cancel_check: Callable[[], bool] | None = None,
     scan_done_callback: Callable[[int, int], None] | None = None,
+    auto_discard_grade: str | None = None,
+    auto_discard_lock_action: str = "skip",
+    config_dir=None,
 ) -> dict:
     """Run gamepad scanning while parsing captured screenshots in a consumer thread."""
 
@@ -31,6 +118,7 @@ def run_streaming_scan_parse(
     added_paths: list[str] = []
     duplicate_paths: list[str] = []
     failed_paths: list[str] = []
+    parsed_items: list[tuple[int, object, bool]] = []
     parse_error: list[BaseException] = []
     parse_start = time.perf_counter()
 
@@ -67,6 +155,10 @@ def run_streaming_scan_parse(
                     )
                     if added:
                         added_paths.append(final_path_for(filename))
+                        locked = isinstance(_item_obj, Drive) and _drive_screenshot_is_locked(temp_path)
+                        if locked:
+                            logger.info(f"跳过锁定驱动弃置目标: {filename}")
+                        parsed_items.append((index, _item_obj, locked))
                     else:
                         duplicate_paths.append(final_path_for(filename))
                         logger.info(f"相邻截图画面与解析数据均一致，按连拍重复过滤: {filename}")
@@ -103,7 +195,7 @@ def run_streaming_scan_parse(
             on_capture=on_capture,
             commit_on_complete=False,
         )
-        if scan_done_callback is not None:
+        if scan_done_callback is not None and not auto_discard_grade:
             scan_done_callback(captured_count, total_drives)
     finally:
         captured_queue.put(_STOP)
@@ -127,12 +219,36 @@ def run_streaming_scan_parse(
         streaming=1,
     )
 
+    discard_targets = []
+    discard_marked = 0
+    discard_locked_targets = []
     if cancel_check is not None and cancel_check():
         logger.warning("流水线扫描已取消，解析结果不会写入库存。")
     elif captured_count == int(total_drives):
+        if auto_discard_grade:
+            discard_targets = _discard_target_indexes(
+                processor,
+                parsed_items,
+                auto_discard_grade,
+                config_dir,
+                auto_discard_lock_action,
+            )
+            locked_indexes = {index for index, _item, locked in parsed_items if locked}
+            discard_locked_targets = [index for index in discard_targets if index in locked_indexes]
         if getattr(processor, "inventory", None):
             processor._export_to_json()
         scanner._commit_temp_output()
+        if auto_discard_grade:
+            if discard_locked_targets:
+                discard_marked = scanner.mark_discard_by_indexes(
+                    total_drives,
+                    discard_targets,
+                    locked_indexes=discard_locked_targets,
+                )
+            else:
+                discard_marked = scanner.mark_discard_by_indexes(total_drives, discard_targets)
+            if scan_done_callback is not None:
+                scan_done_callback(captured_count, total_drives)
 
     return {
         "added_paths": added_paths,
@@ -143,4 +259,8 @@ def run_streaming_scan_parse(
         "failed_count": len(failed_paths),
         "total_count": captured_count,
         "parse_scope": "full",
+        "auto_discard_grade": auto_discard_grade,
+        "discard_target_count": len(discard_targets),
+        "discard_marked_count": discard_marked,
+        "discard_locked_target_count": len(discard_locked_targets),
     }

--- a/src/scanner/gamepad_controller.py
+++ b/src/scanner/gamepad_controller.py
@@ -54,6 +54,7 @@ class GamepadScanner:
             import vgamepad as vg
 
             self.gamepad = vg.VX360Gamepad()
+            self._buttons = vg.XUSB_BUTTON
         except Exception as exc:
             text = str(exc).upper()
             if "VIGEM" in text or "BUS_NOT_FOUND" in text or "VI_GEM" in text:
@@ -127,12 +128,33 @@ class GamepadScanner:
         self.gamepad.update()
         time.sleep(settle_seconds)
 
+    def _press_button(self, button, hold_seconds=0.08, settle_seconds=0.12):
+        self.gamepad.press_button(button=button)
+        self.gamepad.update()
+        time.sleep(hold_seconds)
+        self.gamepad.release_button(button=button)
+        self.gamepad.update()
+        time.sleep(settle_seconds)
+
+    def _press_a(self):
+        self._press_button(self._buttons.XUSB_GAMEPAD_A)
+
+    def _press_menu(self):
+        self._press_button(self._buttons.XUSB_GAMEPAD_START)
+
     def _apply_moves(self, moves):
         for move in moves:
             if move == "R":
                 self.push_left_joystick(1.0, 0.0)
             elif move == "L":
                 self.push_left_joystick(-1.0, 0.0)
+            elif move == "U":
+                self.push_left_joystick(
+                    0.0,
+                    1.0,
+                    hold_seconds=ROW_DOWN_HOLD_SECONDS,
+                    settle_seconds=ROW_DOWN_SETTLE_SECONDS,
+                )
             elif move == "D":
                 self.push_left_joystick(
                     0.0,
@@ -141,7 +163,7 @@ class GamepadScanner:
                     settle_seconds=ROW_DOWN_SETTLE_SECONDS,
                 )
 
-    def _generate_path(self, total_drives: int) -> list:
+    def _scan_positions(self, total_drives: int) -> list[tuple[int, int]]:
         scan_order = []
         for row in range((total_drives + self.cols - 1) // self.cols):
             cols_in_row = min(self.cols, total_drives - row * self.cols)
@@ -151,6 +173,10 @@ class GamepadScanner:
             else:
                 for col in range(cols_in_row - 1, -1, -1):
                     scan_order.append((row, col))
+        return scan_order
+
+    def _generate_path(self, total_drives: int) -> list:
+        scan_order = self._scan_positions(total_drives)
 
         commands = []
         curr_row, curr_col = 0, 0
@@ -167,6 +193,64 @@ class GamepadScanner:
                 curr_row += 1
             commands.append(moves)
         return commands
+
+    def mark_discard_by_indexes(
+        self,
+        total_drives: int,
+        target_indexes: list[int],
+        locked_indexes: list[int] | set[int] | None = None,
+    ) -> int:
+        targets = sorted(
+            {int(index) for index in target_indexes if 1 <= int(index) <= int(total_drives)},
+        )
+        if not targets:
+            return 0
+        locked_targets = {int(index) for index in (locked_indexes or [])}
+
+        row_count = (int(total_drives) + self.cols - 1) // self.cols
+        self._apply_moves(["U"] * row_count + ["L"] * (self.cols - 1))
+
+        positions = self._scan_positions(int(total_drives))
+        curr_row, curr_col = 0, 0
+        marked = 0
+
+        def moves_to(index: int) -> list[str]:
+            nonlocal curr_row, curr_col
+            target_row, target_col = positions[index - 1]
+            moves = []
+            while curr_row > target_row:
+                moves.append("U")
+                curr_row -= 1
+            while curr_row < target_row:
+                moves.append("D")
+                curr_row += 1
+            while curr_col < target_col:
+                moves.append("R")
+                curr_col += 1
+            while curr_col > target_col:
+                moves.append("L")
+                curr_col -= 1
+            return moves
+
+        logger.warning(f"准备标记弃置 {len(targets)} 个低分驱动，请保持游戏背包界面不动。")
+        for index in targets:
+            if self._stopped:
+                break
+            self._apply_moves(moves_to(index))
+            if index in locked_targets:
+                self._press_menu()
+                self._apply_moves(["R"])
+                self._press_a()
+                self._apply_moves(["L"])
+                self._press_a()
+                self._press_menu()
+            else:
+                self._press_menu()
+                self._press_a()
+                self._press_menu()
+            marked += 1
+            logger.info(f"已标记弃置: raw_drive_{index:04d}")
+        return marked
 
     def start_scan(self, total_drives=None, on_capture=None, commit_on_complete=True):
         scan_start = time.perf_counter()

--- a/tests/test_role_execute_workflows.py
+++ b/tests/test_role_execute_workflows.py
@@ -356,6 +356,134 @@ class ExecutePageWorkflowTests(unittest.TestCase):
         self.assertIsNotNone(scroll)
         app.processEvents()
 
+    def test_execute_page_shows_auto_discard_controls_only_for_full_scan(self):
+        from PySide6.QtCore import Signal
+        from PySide6.QtWidgets import QApplication, QFrame, QVBoxLayout, QWidget
+
+        from src.features.allocation.execute_page import build_execute_page
+        from src.features.scanning.controller import _on_scan_change
+
+        app = QApplication.instance() or QApplication([])
+
+        class FakeRoleSelector(QWidget):
+            orderChanged = Signal()
+
+        class Window(QWidget):
+            def _card(self, _title):
+                card = QFrame()
+                QVBoxLayout(card)
+                return card
+
+            def _on_scan_change(self, scan_id):
+                _on_scan_change(self, scan_id)
+
+            def _on_priority_changed(self, *_args):
+                pass
+
+            def _do_exec(self):
+                pass
+
+            def _save_alloc(self, show_message=True):
+                return True
+
+        window = Window()
+        help_calls = []
+        scroll = build_execute_page(window, FakeRoleSelector, {}, {}, {}, lambda *args: help_calls.append(args))
+
+        self.assertTrue(window.auto_discard_frame.isHidden())
+        self.assertTrue(window.auto_discard_grade_combo.isEnabled())
+        self.assertTrue(window.auto_discard_lock_action_combo.isEnabled())
+
+        window._on_scan_change(1)
+        self.assertFalse(window.auto_discard_frame.isHidden())
+        self.assertTrue(window.auto_discard_grade_combo.isEnabled())
+        self.assertTrue(window.auto_discard_lock_action_combo.isEnabled())
+        window.auto_discard_checkbox.setChecked(True)
+        self.assertTrue(window.auto_discard_grade_combo.isEnabled())
+        self.assertTrue(window.auto_discard_lock_action_combo.isEnabled())
+        window.auto_discard_grade_help.click()
+        self.assertEqual("自动弃置评分说明", help_calls[-1][1])
+        self.assertIn("所有角色权重", help_calls[-1][2])
+        self.assertIn("第二步", help_calls[-1][2])
+        self.assertIn("- 选 SS: 只标 S/A/B/C/D", help_calls[-1][2])
+
+        window._on_scan_change(4)
+        self.assertTrue(window.auto_discard_frame.isHidden())
+        app.processEvents()
+
+    def test_auto_discard_checkbox_passes_grade_to_full_scan(self):
+        from src.features.scanning import controller
+
+        original_information = controller.QMessageBox.information
+        controller.QMessageBox.information = lambda *_args, **_kwargs: None
+        try:
+            class RoleSelector:
+                def get_selected(self):
+                    return []
+
+                def get_custom_sets(self):
+                    return {}
+
+                def get_tape_main_filters(self):
+                    return {}
+
+                def get_crit_priority_modes(self):
+                    return {}
+
+                def get_crit_rate_caps(self):
+                    return {}
+
+                def get_set_effect_modes(self):
+                    return {}
+
+                def get_priority_groups(self):
+                    return None
+
+            class ScanGroup:
+                def checkedId(self):
+                    return 1
+
+            class CountEdit:
+                def text(self):
+                    return "10"
+
+            class Checkbox:
+                def isChecked(self):
+                    return True
+
+            class Combo:
+                def currentText(self):
+                    return "S"
+
+                def currentData(self):
+                    return "unlock"
+
+            class Window:
+                def __init__(self):
+                    self.role_selector = RoleSelector()
+                    self.scan_group = ScanGroup()
+                    self.total_count_edit = CountEdit()
+                    self.auto_discard_checkbox = Checkbox()
+                    self.auto_discard_grade_combo = Combo()
+                    self.auto_discard_lock_action_combo = Combo()
+                    self.strategy_group = SimpleNamespace(checkedId=lambda: 0)
+                    self.btn_run = SimpleNamespace(setEnabled=lambda _value: None, setText=lambda _text: None)
+                    self.result_card = SimpleNamespace(setVisible=lambda _value: None)
+                    self.scan_args = []
+
+                def _start_gamepad_scan(self, total_drives, auto_discard_grade=None, auto_discard_lock_action="skip"):
+                    self.scan_args.append((total_drives, auto_discard_grade, auto_discard_lock_action))
+
+                def _confirm_unsaved_allocation_before_recompute(self):
+                    return True
+
+            window = Window()
+            controller._do_exec(window)
+        finally:
+            controller.QMessageBox.information = original_information
+
+        self.assertEqual([(10, "S", "unlock")], window.scan_args)
+
     def test_result_header_grade_uses_full_350_score_even_without_tape(self):
         from PySide6.QtWidgets import QApplication, QFrame, QVBoxLayout
 
@@ -2491,5 +2619,3 @@ class ExecutePageWorkflowTests(unittest.TestCase):
 
         self.assertIn((150.8, 35), captured)
         self.assertNotIn((150.8, 20), captured)
-
-

--- a/tests/test_scanner_helpers.py
+++ b/tests/test_scanner_helpers.py
@@ -988,6 +988,57 @@ class GamepadScannerTests(unittest.TestCase):
         )
         self.assertEqual([], commits)
 
+    def test_mark_discard_resets_to_top_then_marks_in_scan_order(self):
+        from src.scanner import gamepad_controller
+
+        scanner = gamepad_controller.GamepadScanner.__new__(gamepad_controller.GamepadScanner)
+        scanner.cols = 7
+        scanner._stopped = False
+        moves = []
+        presses = []
+        scanner._apply_moves = lambda batch: moves.append(batch)
+        scanner._press_menu = lambda: presses.append("menu")
+        scanner._press_a = lambda: presses.append("a")
+
+        marked = scanner.mark_discard_by_indexes(14, [8, 2])
+
+        self.assertEqual(2, marked)
+        self.assertEqual(
+            [
+                ["U", "U", "L", "L", "L", "L", "L", "L"],
+                ["R"],
+                ["D", "R", "R", "R", "R", "R"],
+            ],
+            moves,
+        )
+        self.assertEqual(["menu", "a", "menu", "menu", "a", "menu"], presses)
+
+    def test_mark_discard_unlocks_locked_target_with_confirmation_sequence(self):
+        from src.scanner import gamepad_controller
+
+        scanner = gamepad_controller.GamepadScanner.__new__(gamepad_controller.GamepadScanner)
+        scanner.cols = 7
+        scanner._stopped = False
+        moves = []
+        presses = []
+        scanner._apply_moves = lambda batch: moves.append(batch)
+        scanner._press_menu = lambda: presses.append("menu")
+        scanner._press_a = lambda: presses.append("a")
+
+        marked = scanner.mark_discard_by_indexes(14, [2], locked_indexes=[2])
+
+        self.assertEqual(1, marked)
+        self.assertEqual(
+            [
+                ["U", "U", "L", "L", "L", "L", "L", "L"],
+                ["R"],
+                ["R"],
+                ["L"],
+            ],
+            moves,
+        )
+        self.assertEqual(["menu", "a", "a", "menu"], presses)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_streaming_scan_pipeline.py
+++ b/tests/test_streaming_scan_pipeline.py
@@ -1,9 +1,12 @@
 # 测试全量扫描与截图解析的流水线执行逻辑。
+import json
 import tempfile
 import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+
+import numpy as np
 
 
 class StreamingScanPipelineTests(unittest.TestCase):
@@ -65,6 +68,330 @@ class StreamingScanPipelineTests(unittest.TestCase):
         self.assertEqual(2, stats["success_count"])
         self.assertEqual(0, stats["failed_count"])
         self.assertEqual("full", stats["parse_scope"])
+
+    def test_auto_discard_marks_low_score_drive_indexes_after_scoring(self):
+        from src.features.scanning.streaming_pipeline import run_streaming_scan_parse
+        from src.models.equipment import Drive
+
+        class FakeScanner:
+            def __init__(self, root):
+                self.output_dir = str(root)
+                self.temp_dir = root / "temp"
+                self.temp_dir.mkdir()
+                self.marked = []
+
+            def start_scan(self, total_drives, on_capture=None, commit_on_complete=True):
+                for index in range(1, total_drives + 1):
+                    path = self.temp_dir / f"raw_drive_{index:04d}.png"
+                    path.write_bytes(b"png")
+                    on_capture(str(path), index, total_drives)
+                return total_drives
+
+            def _commit_temp_output(self):
+                pass
+
+            def mark_discard_by_indexes(self, total_drives, target_indexes):
+                self.marked.append((total_drives, list(target_indexes)))
+                return len(target_indexes)
+
+        class FakeProcessor:
+            def __init__(self, items):
+                self.items = items
+                self.inventory = []
+                self.exported_scores = []
+
+            def process_image_file(self, _image_path, filename, **_kwargs):
+                index = int(filename.removeprefix("raw_drive_").removesuffix(".png"))
+                item = self.items[index - 1]
+                self.inventory.append(item)
+                return item, True
+
+            def _export_to_json(self):
+                self.exported_scores = [item.max_score for item in self.inventory]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_dir = root / "config"
+            config_dir.mkdir()
+            (config_dir / "roles.json").write_text(
+                json.dumps({"A": {"weights": {"Good": 1.0}, "default_set": "Set"}}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            (config_dir / "stats.json").write_text(
+                json.dumps(
+                    {
+                        "gold_base_values": {"Good": 1.0, "Bad": 1.0},
+                        "main_only_keywords": [],
+                        "stat_alias_mapping": {},
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            items = [
+                Drive(
+                    uid="low",
+                    quality="Gold",
+                    area=1,
+                    shape_id="S1",
+                    set_name="Set",
+                    main_stats={"m1": 1.0, "m2": 1.0},
+                    sub_stats={"Bad": 1.0},
+                ),
+                Drive(
+                    uid="high",
+                    quality="Gold",
+                    area=1,
+                    shape_id="S2",
+                    set_name="Set",
+                    main_stats={"m1": 1.0, "m2": 1.0},
+                    sub_stats={"Good": 1.0},
+                ),
+            ]
+            scanner = FakeScanner(root)
+            processor = FakeProcessor(items)
+
+            stats = run_streaming_scan_parse(
+                scanner,
+                processor,
+                total_drives=2,
+                auto_discard_grade="A",
+                config_dir=config_dir,
+            )
+
+        self.assertEqual([(2, [1])], scanner.marked)
+        self.assertEqual(1, stats["discard_target_count"])
+        self.assertEqual(1, stats["discard_marked_count"])
+        self.assertGreater(processor.exported_scores[1], processor.exported_scores[0])
+
+    def test_lock_icon_mask_distinguishes_closed_from_open(self):
+        from src.features.scanning.streaming_pipeline import _lock_icon_mask_is_locked
+
+        closed = np.array(
+            [
+                "....####....",
+                "...######...",
+                "..###..###..",
+                ".##########.",
+                "############",
+                "############",
+                "####....####",
+                "####....####",
+            ],
+            dtype="U12",
+        )
+        opened = np.array(
+            [
+                "....####....",
+                "...######...",
+                "..##....##..",
+                ".##.........",
+                ".##.........",
+                "############",
+                "####....####",
+                "####....####",
+            ],
+            dtype="U12",
+        )
+
+        self.assertTrue(_lock_icon_mask_is_locked(np.char.equal(np.array([list(row) for row in closed]), "#")))
+        self.assertFalse(_lock_icon_mask_is_locked(np.char.equal(np.array([list(row) for row in opened]), "#")))
+
+    def test_auto_discard_skips_locked_drive_indexes(self):
+        from src.features.scanning import streaming_pipeline
+        from src.models.equipment import Drive
+
+        class FakeScanner:
+            def __init__(self, root):
+                self.output_dir = str(root)
+                self.temp_dir = root / "temp"
+                self.temp_dir.mkdir()
+                self.marked = []
+
+            def start_scan(self, total_drives, on_capture=None, commit_on_complete=True):
+                for index in range(1, total_drives + 1):
+                    path = self.temp_dir / f"raw_drive_{index:04d}.png"
+                    path.write_bytes(b"png")
+                    on_capture(str(path), index, total_drives)
+                return total_drives
+
+            def _commit_temp_output(self):
+                pass
+
+            def mark_discard_by_indexes(self, total_drives, target_indexes):
+                self.marked.append((total_drives, list(target_indexes)))
+                return len(target_indexes)
+
+        class FakeProcessor:
+            def __init__(self, items):
+                self.items = items
+                self.inventory = []
+
+            def process_image_file(self, _image_path, filename, **_kwargs):
+                index = int(filename.removeprefix("raw_drive_").removesuffix(".png"))
+                item = self.items[index - 1]
+                self.inventory.append(item)
+                return item, True
+
+            def _export_to_json(self):
+                pass
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_dir = root / "config"
+            config_dir.mkdir()
+            (config_dir / "roles.json").write_text(
+                json.dumps({"A": {"weights": {"Good": 1.0}, "default_set": "Set"}}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            (config_dir / "stats.json").write_text(
+                json.dumps(
+                    {
+                        "gold_base_values": {"Bad": 1.0},
+                        "main_only_keywords": [],
+                        "stat_alias_mapping": {},
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            items = [
+                Drive(
+                    uid="locked-low",
+                    quality="Gold",
+                    area=1,
+                    shape_id="S1",
+                    set_name="Set",
+                    main_stats={"m1": 1.0, "m2": 1.0},
+                    sub_stats={"Bad": 1.0},
+                ),
+                Drive(
+                    uid="unlocked-low",
+                    quality="Gold",
+                    area=1,
+                    shape_id="S2",
+                    set_name="Set",
+                    main_stats={"m1": 1.0, "m2": 1.0},
+                    sub_stats={"Bad": 1.0},
+                ),
+            ]
+            scanner = FakeScanner(root)
+            processor = FakeProcessor(items)
+            original_detector = streaming_pipeline._drive_screenshot_is_locked
+            streaming_pipeline._drive_screenshot_is_locked = lambda path: str(path).endswith("raw_drive_0001.png")
+            try:
+                stats = streaming_pipeline.run_streaming_scan_parse(
+                    scanner,
+                    processor,
+                    total_drives=2,
+                    auto_discard_grade="A",
+                    config_dir=config_dir,
+                )
+            finally:
+                streaming_pipeline._drive_screenshot_is_locked = original_detector
+
+        self.assertEqual([(2, [2])], scanner.marked)
+        self.assertEqual(1, stats["discard_target_count"])
+        self.assertEqual(1, stats["discard_marked_count"])
+
+    def test_auto_discard_unlock_mode_keeps_locked_drive_targets(self):
+        from src.features.scanning import streaming_pipeline
+        from src.models.equipment import Drive
+
+        class FakeScanner:
+            def __init__(self, root):
+                self.output_dir = str(root)
+                self.temp_dir = root / "temp"
+                self.temp_dir.mkdir()
+                self.marked = []
+
+            def start_scan(self, total_drives, on_capture=None, commit_on_complete=True):
+                for index in range(1, total_drives + 1):
+                    path = self.temp_dir / f"raw_drive_{index:04d}.png"
+                    path.write_bytes(b"png")
+                    on_capture(str(path), index, total_drives)
+                return total_drives
+
+            def _commit_temp_output(self):
+                pass
+
+            def mark_discard_by_indexes(self, total_drives, target_indexes, locked_indexes=None):
+                self.marked.append((total_drives, list(target_indexes), list(locked_indexes or [])))
+                return len(target_indexes)
+
+        class FakeProcessor:
+            def __init__(self, items):
+                self.items = items
+                self.inventory = []
+
+            def process_image_file(self, _image_path, filename, **_kwargs):
+                index = int(filename.removeprefix("raw_drive_").removesuffix(".png"))
+                item = self.items[index - 1]
+                self.inventory.append(item)
+                return item, True
+
+            def _export_to_json(self):
+                pass
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config_dir = root / "config"
+            config_dir.mkdir()
+            (config_dir / "roles.json").write_text(
+                json.dumps({"A": {"weights": {"Good": 1.0}, "default_set": "Set"}}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            (config_dir / "stats.json").write_text(
+                json.dumps(
+                    {
+                        "gold_base_values": {"Bad": 1.0},
+                        "main_only_keywords": [],
+                        "stat_alias_mapping": {},
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            items = [
+                Drive(
+                    uid="locked-low",
+                    quality="Gold",
+                    area=1,
+                    shape_id="S1",
+                    set_name="Set",
+                    main_stats={"m1": 1.0, "m2": 1.0},
+                    sub_stats={"Bad": 1.0},
+                ),
+                Drive(
+                    uid="unlocked-low",
+                    quality="Gold",
+                    area=1,
+                    shape_id="S2",
+                    set_name="Set",
+                    main_stats={"m1": 1.0, "m2": 1.0},
+                    sub_stats={"Bad": 1.0},
+                ),
+            ]
+            scanner = FakeScanner(root)
+            processor = FakeProcessor(items)
+            original_detector = streaming_pipeline._drive_screenshot_is_locked
+            streaming_pipeline._drive_screenshot_is_locked = lambda path: str(path).endswith("raw_drive_0001.png")
+            try:
+                stats = streaming_pipeline.run_streaming_scan_parse(
+                    scanner,
+                    processor,
+                    total_drives=2,
+                    auto_discard_grade="A",
+                    auto_discard_lock_action="unlock",
+                    config_dir=config_dir,
+                )
+            finally:
+                streaming_pipeline._drive_screenshot_is_locked = original_detector
+
+        self.assertEqual([(2, [1, 2], [1])], scanner.marked)
+        self.assertEqual(2, stats["discard_target_count"])
+        self.assertEqual(2, stats["discard_marked_count"])
+        self.assertEqual(1, stats["discard_locked_target_count"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

- 在“全量扫描”下新增一个可选的自动标记弃置功能。
- 扫描完成后，会把最高评分低于所选阈值的驱动在游戏内标记为弃置。
- 评分会使用所有已配置的角色权重，不只使用第二步中选中的配装角色。
- 锁定驱动默认跳过；用户也可以显式选择自动解锁并标记弃置。

## 行为说明

- 功能默认关闭。
- 阈值判断是严格低于：选择 `A` 只标记 `B/C/D`，选择 `S` 只标记 `A/B/C/D`，选择 `SS` 只标记 `S/A/B/C/D`。
- 标记弃置只会修改游戏内的弃置标记，不会直接分解或删除道具。

## 风险 / 限制

- 游标回到起点是开环操作：会发送足够多的上/左输入，让游标顶回左上角第一格，但不会通过视觉识别确认游标位置（具体逻辑向上是库存/7，然后加上6次左）。
- 锁定驱动检测基于扫描截图里的锁图标区域；如果分辨率、UI 缩放或截图偏移比较特殊，仍可能误判。
- “自动解锁并弃置”会改变锁定道具的状态；为了更安全，默认行为仍然是跳过锁定驱动。
- 我在自己的客户端上测试过多次全量扫描，表现正常；但如果有更多设备、分辨率和 UI 缩放环境的测试会更好一点。

## 测试

- `uv run --with-requirements requirements.txt python -m unittest tests.test_role_execute_workflows tests.test_scanner_helpers tests.test_streaming_scan_pipeline` 通过：94 个测试。
- `uv run --with-requirements requirements.txt python -m py_compile src\features\allocation\execute_page.py src\app\theme.py tests\test_role_execute_workflows.py` 通过。
- `git diff --check` 通过。
- `uv run --with-requirements requirements.txt python -m PyInstaller NTE_Drive_Calc.spec --noconfirm --clean --distpath dist_toggle_round --workpath build_toggle_round` 本地构建通过，构建产物已清理。
- 完整 `python -m unittest discover tests` 当前有一个与本功能无关的既有失败：`tests/test_extension_support.py` 期望存在 `docs/architecture.md`，但当前 checkout 没有 `docs/` 目录。