### PR TITLE
feat：词条自选支持等级门槛与暴击率最小值

### DIFF
--- a/src/domain/crit_threshold.py
+++ b/src/domain/crit_threshold.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from src.domain.grade_limits import GRADE_LADDER, meets_min_grade
+
 CRIT_STAT = "暴击率%"
 CRIT_RANK_BONUS = 100_000.0
 DEFAULT_CRIT_THRESHOLD = 5.0
@@ -32,7 +34,7 @@ def _canonical_stat_name(stat: str, alias_mapping: dict | None = None) -> str:
     return aliases.get(stat, stat)
 
 
-def _is_crit_stat(stat: str, alias_mapping: dict | None = None) -> bool:
+def is_crit_stat(stat: str, alias_mapping: dict | None = None) -> bool:
     canonical = _canonical_stat_name(stat, alias_mapping)
     normalized = canonical.replace("%", "")
     return normalized == "暴击率" or canonical == CRIT_STAT
@@ -79,7 +81,7 @@ def _drive_area(drive: Any, shape_areas: dict | None = None) -> int:
 
 def drive_has_crit(item: Any, alias_mapping: dict | None = None) -> bool:
     for stat in (_item_value(item, "sub_stats", {}) or {}).keys():
-        if _is_crit_stat(stat, alias_mapping):
+        if is_crit_stat(stat, alias_mapping):
             return True
     return False
 
@@ -89,7 +91,7 @@ def normalize_preference_config(config: dict | None) -> dict:
         return {}
     stats = [str(s) for s in config.get("stats", []) if s]
     min_grade = str(config.get("min_grade_limit") or "A").upper()
-    if min_grade not in {"D", "C", "B", "A", "S", "SS", "SSS", "ACE"}:
+    if min_grade not in GRADE_LADDER:
         min_grade = "A"
     raw_threshold = config.get("crit_threshold", config.get("crit_min_threshold", DEFAULT_CRIT_THRESHOLD))
     try:
@@ -107,7 +109,6 @@ def normalize_preference_config(config: dict | None) -> dict:
 
 
 def preference_config_active(config: dict | None) -> bool:
-    """True when the role has a meaningful preference entry."""
     if not isinstance(config, dict) or not config:
         return False
     normalized = normalize_preference_config(config)
@@ -122,15 +123,89 @@ def preference_config_active(config: dict | None) -> bool:
 
 
 def crit_floor_enabled(config: dict | None) -> bool:
-    """Crit floor / greedy only when an explicit threshold key is present.
-
-    UI always persists ``crit_threshold`` when saving preference configs, so the
-    default (5%) still applies after a normal save. Bare ``{"stats": [...]}``
-    without a threshold key does not switch the multi-role solver to greedy.
-    """
+    # 仅显式写入 crit_threshold / crit_min_threshold 时启用暴击下限与 greedy
     if not isinstance(config, dict) or not config:
         return False
     return "crit_threshold" in config or "crit_min_threshold" in config
+
+
+def meets_preference_grade_limit(
+    score: float,
+    area: int,
+    config: dict | None,
+    *,
+    require_active: bool = False,
+) -> bool:
+    if require_active and not preference_config_active(config):
+        return False
+    if not isinstance(config, dict):
+        return meets_min_grade(score, area, "A")
+    normalized = normalize_preference_config(config)
+    if normalized.get("ignore_grade_limit"):
+        return True
+    return meets_min_grade(score, area, normalized.get("min_grade_limit", "A"))
+
+
+def _dedupe_stats(stats) -> list[str]:
+    clean: list[str] = []
+    seen: set[str] = set()
+    for stat in stats or []:
+        name = str(stat or "").strip()
+        if name and name not in seen:
+            seen.add(name)
+            clean.append(name)
+    return clean
+
+
+def _stat_priority_should_persist(normalized: dict) -> bool:
+    has_custom_grade = (
+        not normalized.get("ignore_grade_limit")
+        and str(normalized.get("min_grade_limit", "A")).upper() != "A"
+    )
+    has_custom_crit = int(normalized.get("crit_threshold", DEFAULT_CRIT_THRESHOLD)) != int(DEFAULT_CRIT_THRESHOLD)
+    return bool(
+        normalized.get("stats")
+        or has_custom_grade
+        or has_custom_crit
+        or normalized.get("equal_priority")
+        or normalized.get("ignore_grade_limit")
+    )
+
+
+def persistable_stat_priority_config(
+    cfg: dict,
+    *,
+    allowed_stats: set[str] | frozenset[str] | None = None,
+    dedupe_stats: bool = False,
+) -> dict | None:
+    if not isinstance(cfg, dict):
+        return None
+    if dedupe_stats:
+        stats = _dedupe_stats(cfg.get("stats", []))
+    else:
+        stats = [stat for stat in cfg.get("stats", []) if stat]
+    if allowed_stats is not None:
+        stats = [stat for stat in stats if stat in allowed_stats]
+    payload = {
+        "stats": stats,
+        "equal_priority": bool(cfg.get("equal_priority", False)),
+        "ignore_grade_limit": bool(cfg.get("ignore_grade_limit", False)),
+        "min_grade_limit": cfg.get("min_grade_limit", "A"),
+    }
+    if "crit_threshold" in cfg:
+        payload["crit_threshold"] = cfg["crit_threshold"]
+    elif "crit_min_threshold" in cfg:
+        payload["crit_min_threshold"] = cfg["crit_min_threshold"]
+    normalized = normalize_preference_config(payload)
+    if not _stat_priority_should_persist(normalized):
+        return None
+    return {
+        "stats": normalized["stats"],
+        "equal_priority": normalized["equal_priority"],
+        "ignore_grade_limit": normalized["ignore_grade_limit"],
+        "min_grade_limit": normalized["min_grade_limit"],
+        "crit_threshold": int(normalized["crit_threshold"]),
+    }
 
 
 def crit_rank_adjustment(
@@ -183,12 +258,12 @@ def loadout_crit_total(
             if _drive_area(drive, shape_areas) == target_area:
                 matched_count += 1
     for stat, value in extra_buffs.items():
-        if _is_crit_stat(stat, alias_mapping):
+        if is_crit_stat(stat, alias_mapping):
             _add_crit_total(totals, stat, _stat_number_value(value) * matched_count, alias_mapping)
 
     crit_key = CRIT_STAT
     for stat, value in totals.items():
-        if _is_crit_stat(stat, alias_mapping):
+        if is_crit_stat(stat, alias_mapping):
             crit_key = stat
             break
     return totals.get(crit_key, totals.get(CRIT_STAT, 0.0))

--- a/src/domain/crit_threshold.py
+++ b/src/domain/crit_threshold.py
@@ -8,10 +8,7 @@ from typing import Any
 
 CRIT_STAT = "暴击率%"
 CRIT_RANK_BONUS = 100_000.0
-DEFAULT_CRIT_THRESHOLD = 20.0
-DEFAULT_CRIT_RATE_CAP = 95.0
-# 兼容旧配置键名
-DEFAULT_CRIT_MIN = DEFAULT_CRIT_THRESHOLD
+DEFAULT_CRIT_THRESHOLD = 5.0
 
 
 def _item_value(item: Any, key: str, default=None):
@@ -72,8 +69,12 @@ def _drive_area(drive: Any, shape_areas: dict | None = None) -> int:
         return int(area or 0)
     shape_id = str(_item_value(drive, "shape_id", "") or "")
     if shape_areas and shape_id in shape_areas:
-        return int(shape_areas.get(shape_id, 0) or 0)
-    return 0
+        try:
+            return int(shape_areas.get(shape_id, 0) or 0)
+        except (TypeError, ValueError):
+            pass
+    numbers = re.findall(r"\d+", shape_id)
+    return int(numbers[0]) if numbers else 0
 
 
 def drive_has_crit(item: Any, alias_mapping: dict | None = None) -> bool:
@@ -81,14 +82,6 @@ def drive_has_crit(item: Any, alias_mapping: dict | None = None) -> bool:
         if _is_crit_stat(stat, alias_mapping):
             return True
     return False
-
-
-def drive_crit_value(item: Any, alias_mapping: dict | None = None) -> float:
-    total = 0.0
-    for stat, value in (_item_value(item, "sub_stats", {}) or {}).items():
-        if _is_crit_stat(stat, alias_mapping):
-            total += _stat_number_value(value)
-    return total
 
 
 def normalize_preference_config(config: dict | None) -> dict:
@@ -114,7 +107,30 @@ def normalize_preference_config(config: dict | None) -> dict:
 
 
 def preference_config_active(config: dict | None) -> bool:
-    return bool(normalize_preference_config(config))
+    """True when the role has a meaningful preference entry."""
+    if not isinstance(config, dict) or not config:
+        return False
+    normalized = normalize_preference_config(config)
+    return bool(
+        normalized.get("stats")
+        or normalized.get("equal_priority")
+        or normalized.get("ignore_grade_limit")
+        or str(normalized.get("min_grade_limit", "A")).upper() != "A"
+        or "crit_threshold" in config
+        or "crit_min_threshold" in config
+    )
+
+
+def crit_floor_enabled(config: dict | None) -> bool:
+    """Crit floor / greedy only when an explicit threshold key is present.
+
+    UI always persists ``crit_threshold`` when saving preference configs, so the
+    default (5%) still applies after a normal save. Bare ``{"stats": [...]}``
+    without a threshold key does not switch the multi-role solver to greedy.
+    """
+    if not isinstance(config, dict) or not config:
+        return False
+    return "crit_threshold" in config or "crit_min_threshold" in config
 
 
 def crit_rank_adjustment(
@@ -158,9 +174,8 @@ def loadout_crit_total(
             _add_crit_total(totals, stat, value, alias_mapping)
 
     extra_buffs = role_data.get("extra_shape_buffs", {}) or {}
-    if isinstance(extra_buffs, dict) and len(extra_buffs) > 1:
-        first_key = next(iter(extra_buffs))
-        extra_buffs = {first_key: extra_buffs[first_key]}
+    if not isinstance(extra_buffs, dict):
+        extra_buffs = {}
     target_area = _extra_shape_area(role_data)
     matched_count = 0
     if target_area:

--- a/src/domain/crit_threshold.py
+++ b/src/domain/crit_threshold.py
@@ -208,6 +208,43 @@ def persistable_stat_priority_config(
     }
 
 
+def character_crit_baseline(character_data: dict | None, *, alias_mapping: dict | None = None) -> float:
+    if not isinstance(character_data, dict):
+        return 0.0
+    total = 0.0
+    for stat, value in (character_data.get("sub_stats") or {}).items():
+        if is_crit_stat(stat, alias_mapping):
+            total += _stat_number_value(value)
+    weapon = character_data.get("weapon")
+    if isinstance(weapon, dict):
+        for stat, value in (weapon.get("sub_stats") or {}).items():
+            if is_crit_stat(stat, alias_mapping):
+                total += _stat_number_value(value)
+    return total
+
+
+def character_crit_total(
+    character_data: dict | None,
+    role_data: dict,
+    tape: Any | None,
+    drives: list[Any] | None,
+    *,
+    alias_mapping: dict | None = None,
+    tape_main_values: dict | None = None,
+    shape_areas: dict | None = None,
+) -> float:
+    baseline = character_crit_baseline(character_data, alias_mapping=alias_mapping)
+    loadout = loadout_crit_total(
+        role_data,
+        tape,
+        drives,
+        alias_mapping=alias_mapping,
+        tape_main_values=tape_main_values,
+        shape_areas=shape_areas,
+    )
+    return round(baseline + loadout, 4)
+
+
 def crit_rank_adjustment(
     current_crit: float,
     drive_has_crit_stat: bool,

--- a/src/domain/crit_threshold.py
+++ b/src/domain/crit_threshold.py
@@ -1,0 +1,179 @@
+# 暴击率阈值与配装累计暴击计算。
+"""Crit rate accumulation and rank adjustments for role-priority allocation."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+CRIT_STAT = "暴击率%"
+CRIT_RANK_BONUS = 100_000.0
+DEFAULT_CRIT_THRESHOLD = 20.0
+DEFAULT_CRIT_RATE_CAP = 95.0
+# 兼容旧配置键名
+DEFAULT_CRIT_MIN = DEFAULT_CRIT_THRESHOLD
+
+
+def _item_value(item: Any, key: str, default=None):
+    if isinstance(item, dict):
+        return item.get(key, default)
+    return getattr(item, key, default)
+
+
+def _stat_number_value(value) -> float:
+    try:
+        return float(str(value).replace("%", "").strip())
+    except Exception:
+        return 0.0
+
+
+def _canonical_stat_name(stat: str, alias_mapping: dict | None = None) -> str:
+    stat = str(stat or "").strip()
+    if not stat:
+        return ""
+    aliases = alias_mapping or {}
+    return aliases.get(stat, stat)
+
+
+def _is_crit_stat(stat: str, alias_mapping: dict | None = None) -> bool:
+    canonical = _canonical_stat_name(stat, alias_mapping)
+    normalized = canonical.replace("%", "")
+    return normalized == "暴击率" or canonical == CRIT_STAT
+
+
+def _add_crit_total(totals: dict[str, float], stat: str, value, alias_mapping: dict | None = None) -> None:
+    canonical = _canonical_stat_name(stat, alias_mapping)
+    numeric = _stat_number_value(value)
+    if not canonical or numeric == 0:
+        return
+    totals[canonical] = round(totals.get(canonical, 0.0) + numeric, 4)
+
+
+def _fallback_tape_main_value(main_stat: str, quality: str = "Gold", tape_main_values: dict | None = None) -> float:
+    configured = tape_main_values or {}
+    main_stat = str(main_stat or "").strip()
+    quality_coef = {"Gold": 1.0, "Purple": 0.8, "Blue": 0.6}.get(str(quality or "Gold"), 1.0)
+    if main_stat in configured:
+        return _stat_number_value(configured[main_stat]) * quality_coef
+    if main_stat.replace("%", "") in {"暴击率", "暴击率%"} or main_stat == CRIT_STAT:
+        return 30.0 * quality_coef
+    return 0.0
+
+
+def _extra_shape_area(role_data: dict) -> int | None:
+    label = str(role_data.get("extra_shape_label", "") or "")
+    match = re.search(r"(\d+)", label)
+    return int(match.group(1)) if match else None
+
+
+def _drive_area(drive: Any, shape_areas: dict | None = None) -> int:
+    area = _item_value(drive, "area", None)
+    if area is not None:
+        return int(area or 0)
+    shape_id = str(_item_value(drive, "shape_id", "") or "")
+    if shape_areas and shape_id in shape_areas:
+        return int(shape_areas.get(shape_id, 0) or 0)
+    return 0
+
+
+def drive_has_crit(item: Any, alias_mapping: dict | None = None) -> bool:
+    for stat in (_item_value(item, "sub_stats", {}) or {}).keys():
+        if _is_crit_stat(stat, alias_mapping):
+            return True
+    return False
+
+
+def drive_crit_value(item: Any, alias_mapping: dict | None = None) -> float:
+    total = 0.0
+    for stat, value in (_item_value(item, "sub_stats", {}) or {}).items():
+        if _is_crit_stat(stat, alias_mapping):
+            total += _stat_number_value(value)
+    return total
+
+
+def normalize_preference_config(config: dict | None) -> dict:
+    if not isinstance(config, dict):
+        return {}
+    stats = [str(s) for s in config.get("stats", []) if s]
+    min_grade = str(config.get("min_grade_limit") or "A").upper()
+    if min_grade not in {"D", "C", "B", "A", "S", "SS", "SSS", "ACE"}:
+        min_grade = "A"
+    raw_threshold = config.get("crit_threshold", config.get("crit_min_threshold", DEFAULT_CRIT_THRESHOLD))
+    try:
+        crit_threshold = float(raw_threshold)
+    except (TypeError, ValueError):
+        crit_threshold = DEFAULT_CRIT_THRESHOLD
+    crit_threshold = max(0.0, min(100.0, crit_threshold))
+    return {
+        "stats": stats,
+        "equal_priority": bool(config.get("equal_priority", False)),
+        "ignore_grade_limit": bool(config.get("ignore_grade_limit", False)),
+        "min_grade_limit": min_grade,
+        "crit_threshold": crit_threshold,
+    }
+
+
+def preference_config_active(config: dict | None) -> bool:
+    return bool(normalize_preference_config(config))
+
+
+def crit_rank_adjustment(
+    current_crit: float,
+    drive_has_crit_stat: bool,
+    threshold: float = DEFAULT_CRIT_THRESHOLD,
+) -> float:
+    if not drive_has_crit_stat:
+        return 0.0
+    if current_crit < threshold:
+        return CRIT_RANK_BONUS
+    return 0.0
+
+
+def loadout_crit_total(
+    role_data: dict,
+    tape: Any | None,
+    drives: list[Any] | None,
+    *,
+    alias_mapping: dict | None = None,
+    tape_main_values: dict | None = None,
+    shape_areas: dict | None = None,
+) -> float:
+    totals: dict[str, float] = {}
+    if tape:
+        main_stat = _item_value(tape, "main_stats", "")
+        main_value = _item_value(tape, "main_value", None)
+        if main_value is None:
+            main_value = _fallback_tape_main_value(
+                main_stat,
+                _item_value(tape, "quality", "Gold"),
+                tape_main_values,
+            )
+        _add_crit_total(totals, main_stat, main_value, alias_mapping)
+        for stat, value in (_item_value(tape, "sub_stats", {}) or {}).items():
+            _add_crit_total(totals, stat, value, alias_mapping)
+
+    drives = list(drives or [])
+    for drive in drives:
+        for stat, value in (_item_value(drive, "sub_stats", {}) or {}).items():
+            _add_crit_total(totals, stat, value, alias_mapping)
+
+    extra_buffs = role_data.get("extra_shape_buffs", {}) or {}
+    if isinstance(extra_buffs, dict) and len(extra_buffs) > 1:
+        first_key = next(iter(extra_buffs))
+        extra_buffs = {first_key: extra_buffs[first_key]}
+    target_area = _extra_shape_area(role_data)
+    matched_count = 0
+    if target_area:
+        for drive in drives:
+            if _drive_area(drive, shape_areas) == target_area:
+                matched_count += 1
+    for stat, value in extra_buffs.items():
+        if _is_crit_stat(stat, alias_mapping):
+            _add_crit_total(totals, stat, _stat_number_value(value) * matched_count, alias_mapping)
+
+    crit_key = CRIT_STAT
+    for stat, value in totals.items():
+        if _is_crit_stat(stat, alias_mapping):
+            crit_key = stat
+            break
+    return totals.get(crit_key, totals.get(CRIT_STAT, 0.0))

--- a/src/domain/grade_limits.py
+++ b/src/domain/grade_limits.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 GRADE_LADDER: tuple[str, ...] = ("D", "C", "B", "A", "S", "SS", "SSS", "ACE")
-STAT_PRIORITY_GRADE_OPTIONS: tuple[str, ...] = GRADE_LADDER
 
 GRADE_MIN_RATIOS: dict[str, float] = {
     "D": 0.0,

--- a/src/domain/grade_limits.py
+++ b/src/domain/grade_limits.py
@@ -1,0 +1,27 @@
+# 装备等级门槛常量与判断（无 scoring 依赖）。
+"""Grade ladder thresholds shared by scoring, strategies, and UI."""
+
+from __future__ import annotations
+
+GRADE_LADDER: tuple[str, ...] = ("D", "C", "B", "A", "S", "SS", "SSS", "ACE")
+STAT_PRIORITY_GRADE_OPTIONS: tuple[str, ...] = GRADE_LADDER
+
+GRADE_MIN_RATIOS: dict[str, float] = {
+    "D": 0.0,
+    "C": 0.2,
+    "B": 0.3,
+    "A": 0.4,
+    "S": 0.5,
+    "SS": 0.6,
+    "SSS": 0.7,
+    "ACE": 0.8,
+}
+
+
+def meets_min_grade(score: float, area: int, min_grade: str) -> bool:
+    normalized = str(min_grade or "A").upper()
+    ratio_threshold = GRADE_MIN_RATIOS.get(normalized, GRADE_MIN_RATIOS["A"])
+    max_score = float(area or 0) * 10.0
+    if max_score <= 0:
+        return normalized == "D"
+    return float(score or 0.0) / max_score >= ratio_threshold

--- a/src/features/allocation/role_selector.py
+++ b/src/features/allocation/role_selector.py
@@ -22,6 +22,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QPushButton,
     QScrollArea,
+    QSpinBox,
     QVBoxLayout,
     QWidget,
     QLineEdit,
@@ -29,6 +30,8 @@ from PySide6.QtWidgets import (
 
 from src.ui.widgets import SearchableComboBox, match_pinyin
 from src.app.theme import current_theme_name, themed_style
+from src.domain.crit_threshold import DEFAULT_CRIT_THRESHOLD
+from src.domain.grade_limits import STAT_PRIORITY_GRADE_OPTIONS
 from src.features.allocation.priority_groups import (
     cycle_priority_link,
     links_to_priority_groups,
@@ -453,16 +456,37 @@ class RoleSelector(QWidget):
             self.tape_main_filters.pop(name, None)
         self.orderChanged.emit()
 
-    def _set_stat_priority_config(self, name, stats, equal_priority=False, ignore_grade_limit=False):
+    def _set_stat_priority_config(
+        self,
+        name,
+        stats,
+        equal_priority=False,
+        ignore_grade_limit=False,
+        min_grade_limit="A",
+        crit_threshold=DEFAULT_CRIT_THRESHOLD,
+    ):
         clean = []
         for stat in stats or []:
             if stat and stat in self.drive_sub_stats and stat not in clean:
                 clean.append(stat)
-        if clean:
+        try:
+            crit_value = int(crit_threshold)
+        except (TypeError, ValueError):
+            crit_value = int(DEFAULT_CRIT_THRESHOLD)
+        crit_value = max(0, min(100, crit_value))
+        min_grade = str(min_grade_limit or "A").upper()
+        if min_grade not in STAT_PRIORITY_GRADE_OPTIONS:
+            min_grade = "A"
+        has_custom_grade = not ignore_grade_limit and min_grade != "A"
+        has_custom_crit = crit_value != int(DEFAULT_CRIT_THRESHOLD)
+        has_options = bool(equal_priority or ignore_grade_limit)
+        if clean or has_custom_grade or has_custom_crit or has_options:
             self.stat_priority_configs[name] = {
                 "stats": clean,
                 "equal_priority": bool(equal_priority),
                 "ignore_grade_limit": bool(ignore_grade_limit),
+                "min_grade_limit": min_grade,
+                "crit_threshold": crit_value,
             }
         else:
             self.stat_priority_configs.pop(name, None)
@@ -621,6 +645,44 @@ class RoleSelector(QWidget):
         stat_option_row.addWidget(help_btn)
         stat_option_row.addStretch(1)
         stat_layout.addLayout(stat_option_row)
+
+        grade_row = QHBoxLayout()
+        grade_row.setSpacing(8)
+        grade_label = QLabel("最低生效等级")
+        grade_combo = QComboBox()
+        for grade in STAT_PRIORITY_GRADE_OPTIONS:
+            grade_combo.addItem(grade, grade)
+        current_min_grade = str(current_stat_cfg.get("min_grade_limit") or "A").upper()
+        grade_index = grade_combo.findData(current_min_grade)
+        grade_combo.setCurrentIndex(grade_index if grade_index >= 0 else grade_combo.findData("A"))
+        grade_combo.setEnabled(not ignore_grade_limit.isChecked())
+        grade_row.addWidget(grade_label)
+        grade_row.addWidget(grade_combo, 1)
+        stat_layout.addLayout(grade_row)
+
+        crit_row = QHBoxLayout()
+        crit_row.setSpacing(8)
+        crit_threshold_label = QLabel("暴击率阈值")
+        crit_threshold_spin = QSpinBox()
+        crit_threshold_spin.setRange(0, 100)
+        crit_threshold_spin.setSuffix("%")
+        raw_threshold = current_stat_cfg.get(
+            "crit_threshold",
+            current_stat_cfg.get("crit_min_threshold", DEFAULT_CRIT_THRESHOLD),
+        )
+        try:
+            crit_threshold_spin.setValue(int(raw_threshold))
+        except (TypeError, ValueError):
+            crit_threshold_spin.setValue(int(DEFAULT_CRIT_THRESHOLD))
+        crit_row.addWidget(crit_threshold_label)
+        crit_row.addWidget(crit_threshold_spin)
+        crit_row.addStretch(1)
+        stat_layout.addLayout(crit_row)
+
+        def sync_grade_combo_enabled(checked=False):
+            grade_combo.setEnabled(not ignore_grade_limit.isChecked())
+
+        ignore_grade_limit.toggled.connect(sync_grade_combo_enabled)
         template_layout.addWidget(stat_box)
         layout.addWidget(template_box)
 
@@ -684,6 +746,8 @@ class RoleSelector(QWidget):
                 selected_stats,
                 stat_equal.isChecked(),
                 ignore_grade_limit.isChecked(),
+                grade_combo.currentData(),
+                crit_threshold_spin.value(),
             )
             cap_text = crit_cap_edit.text().strip()
             if cap_text or not selected_weapon:
@@ -872,11 +936,28 @@ class RoleSelector(QWidget):
                 if role not in self.all_roles or not isinstance(cfg_item, dict):
                     continue
                 stats = [s for s in cfg_item.get("stats", []) if s in self.drive_sub_stats]
-                if stats:
+                min_grade = str(cfg_item.get("min_grade_limit") or "A").upper()
+                if min_grade not in STAT_PRIORITY_GRADE_OPTIONS:
+                    min_grade = "A"
+                try:
+                    raw_threshold = cfg_item.get(
+                        "crit_threshold",
+                        cfg_item.get("crit_min_threshold", DEFAULT_CRIT_THRESHOLD),
+                    )
+                    crit_value = int(raw_threshold)
+                except (TypeError, ValueError):
+                    crit_value = int(DEFAULT_CRIT_THRESHOLD)
+                ignore_grade = bool(cfg_item.get("ignore_grade_limit", False))
+                equal_priority = bool(cfg_item.get("equal_priority", False))
+                has_custom_grade = not ignore_grade and min_grade != "A"
+                has_custom_crit = crit_value != int(DEFAULT_CRIT_THRESHOLD)
+                if stats or has_custom_grade or has_custom_crit or ignore_grade or equal_priority:
                     self.stat_priority_configs[role] = {
                         "stats": stats,
-                        "equal_priority": bool(cfg_item.get("equal_priority", False)),
-                        "ignore_grade_limit": bool(cfg_item.get("ignore_grade_limit", False)),
+                        "equal_priority": equal_priority,
+                        "ignore_grade_limit": ignore_grade,
+                        "min_grade_limit": min_grade,
+                        "crit_threshold": max(0, min(100, crit_value)),
                     }
             self.set_effect_modes = {}
             for role, mode in data.get("set_effect_modes", {}).items():
@@ -923,8 +1004,11 @@ STAT_PRIORITY_HELP = (
     "卡带/驱动副词条：让该角色优先使用带有所选副词条的驱动。\n"
     "关闭“优先级一致”时，按选择顺序逐层优先，例如 A > B > C 会优先使用同时含 A+B+C、再含 A+B、再含 A 的驱动。\n"
     "开启“优先级一致”时，优先使用命中副词条数量更多的驱动。\n\n"
-    "默认只对评分达到 A 级的驱动生效。\n"
-    "勾选“不限制评分等级”后，会按整张图纸的自选副词条覆盖程度优先；覆盖相同时再比较评分。"
+    "未勾选“不限制评分等级”时，可通过“最低生效等级”选择 D 至 ACE 的门槛；"
+    "默认 A 级。词条自选加成与暴击率阈值加成都受该门槛约束。\n"
+    "勾选“不限制评分等级”后，会按整张图纸的自选副词条覆盖程度优先；覆盖相同时再比较评分。\n\n"
+    "暴击率阈值会参考当前配装的累计暴击率：低于阈值时，仅对达到最低生效等级的驱动优先选择带暴击词条的；"
+    "达到阈值后取消该加成。暴击率上限会硬性限制配装总暴击。"
 )
 
 

--- a/src/features/allocation/role_selector.py
+++ b/src/features/allocation/role_selector.py
@@ -657,6 +657,12 @@ class RoleSelector(QWidget):
         limits_row.addSpacing(20)
 
         crit_threshold_label = QLabel("暴击率最小值")
+        crit_threshold_help = QPushButton("?")
+        crit_threshold_help.setObjectName("btnHelp")
+        crit_threshold_help.setFixedSize(24, 24)
+        crit_threshold_help.clicked.connect(
+            lambda: self._show_help("暴击率最小值", CRIT_THRESHOLD_HELP)
+        )
         crit_threshold_spin = QSpinBox()
         crit_threshold_spin.setRange(0, 100)
         crit_threshold_spin.setSuffix("%")
@@ -670,6 +676,7 @@ class RoleSelector(QWidget):
         except (TypeError, ValueError):
             crit_threshold_spin.setValue(int(DEFAULT_CRIT_THRESHOLD))
         limits_row.addWidget(crit_threshold_label)
+        limits_row.addWidget(crit_threshold_help)
         limits_row.addWidget(crit_threshold_spin)
         limits_row.addStretch(1)
         stat_layout.addLayout(limits_row)
@@ -982,8 +989,15 @@ STAT_PRIORITY_HELP = (
     "未勾选“不限制评分等级”时，可通过“最低生效等级”选择 D 至 ACE 的门槛；"
     "默认 A 级。词条自选加成与暴击率最小值加成都受该门槛约束。\n"
     "勾选“不限制评分等级”后，会按整张图纸的自选副词条覆盖程度优先；覆盖相同时再比较评分。\n\n"
-    "暴击率最小值会参考当前配装的累计暴击率：低于该值时，仅对达到最低生效等级的驱动优先选择带暴击词条的；"
-    "达到后取消该加成。暴击率上限会硬性限制配装总暴击。"
+    "暴击率最小值按角色侧累计暴击判断，详见该项旁的 ? 说明。暴击率上限会硬性限制配装总暴击。"
+)
+
+
+CRIT_THRESHOLD_HELP = (
+    "按角色页的基础暴击率累计，并叠加当前配装进度（卡带、驱动、空幕额外形加成）。\n\n"
+    "计入：角色基础属性中的暴击率；弧盘基础属性中的暴击率（若含该词条）。\n\n"
+    "不计入：好感度加成；弧盘混频被动技能；战斗中触发的临时/实战暴击增益。\n\n"
+    "低于设定值时，仅对达到最低生效等级的驱动优先选择带暴击词条的；达到后取消该加成。"
 )
 
 

--- a/src/features/allocation/role_selector.py
+++ b/src/features/allocation/role_selector.py
@@ -30,8 +30,8 @@ from PySide6.QtWidgets import (
 
 from src.ui.widgets import SearchableComboBox, match_pinyin
 from src.app.theme import current_theme_name, themed_style
-from src.domain.crit_threshold import DEFAULT_CRIT_THRESHOLD
-from src.domain.grade_limits import STAT_PRIORITY_GRADE_OPTIONS
+from src.domain.crit_threshold import DEFAULT_CRIT_THRESHOLD, persistable_stat_priority_config
+from src.domain.grade_limits import GRADE_LADDER
 from src.features.allocation.priority_groups import (
     cycle_priority_link,
     links_to_priority_groups,
@@ -465,29 +465,19 @@ class RoleSelector(QWidget):
         min_grade_limit="A",
         crit_threshold=DEFAULT_CRIT_THRESHOLD,
     ):
-        clean = []
-        for stat in stats or []:
-            if stat and stat in self.drive_sub_stats and stat not in clean:
-                clean.append(stat)
-        try:
-            crit_value = int(crit_threshold)
-        except (TypeError, ValueError):
-            crit_value = int(DEFAULT_CRIT_THRESHOLD)
-        crit_value = max(0, min(100, crit_value))
-        min_grade = str(min_grade_limit or "A").upper()
-        if min_grade not in STAT_PRIORITY_GRADE_OPTIONS:
-            min_grade = "A"
-        has_custom_grade = not ignore_grade_limit and min_grade != "A"
-        has_custom_crit = crit_value != int(DEFAULT_CRIT_THRESHOLD)
-        has_options = bool(equal_priority or ignore_grade_limit)
-        if clean or has_custom_grade or has_custom_crit or has_options:
-            self.stat_priority_configs[name] = {
-                "stats": clean,
-                "equal_priority": bool(equal_priority),
-                "ignore_grade_limit": bool(ignore_grade_limit),
-                "min_grade_limit": min_grade,
-                "crit_threshold": crit_value,
-            }
+        cfg = persistable_stat_priority_config(
+            {
+                "stats": stats or [],
+                "equal_priority": equal_priority,
+                "ignore_grade_limit": ignore_grade_limit,
+                "min_grade_limit": min_grade_limit,
+                "crit_threshold": crit_threshold,
+            },
+            allowed_stats=set(self.drive_sub_stats),
+            dedupe_stats=True,
+        )
+        if cfg:
+            self.stat_priority_configs[name] = cfg
         else:
             self.stat_priority_configs.pop(name, None)
         self.orderChanged.emit()
@@ -656,7 +646,7 @@ class RoleSelector(QWidget):
         grade_label = QLabel("最低生效等级")
         grade_combo = QComboBox()
         grade_combo.setFixedWidth(84)
-        for grade in STAT_PRIORITY_GRADE_OPTIONS:
+        for grade in GRADE_LADDER:
             grade_combo.addItem(grade, grade)
         current_min_grade = str(current_stat_cfg.get("min_grade_limit") or "A").upper()
         grade_index = grade_combo.findData(current_min_grade)
@@ -937,33 +927,13 @@ class RoleSelector(QWidget):
                 if role in self.all_roles and isinstance(values, list)
             }
             self.stat_priority_configs = {}
+            allowed_stats = set(self.drive_sub_stats)
             for role, cfg_item in data.get("stat_priority_configs", {}).items():
                 if role not in self.all_roles or not isinstance(cfg_item, dict):
                     continue
-                stats = [s for s in cfg_item.get("stats", []) if s in self.drive_sub_stats]
-                min_grade = str(cfg_item.get("min_grade_limit") or "A").upper()
-                if min_grade not in STAT_PRIORITY_GRADE_OPTIONS:
-                    min_grade = "A"
-                try:
-                    raw_threshold = cfg_item.get(
-                        "crit_threshold",
-                        cfg_item.get("crit_min_threshold", DEFAULT_CRIT_THRESHOLD),
-                    )
-                    crit_value = int(raw_threshold)
-                except (TypeError, ValueError):
-                    crit_value = int(DEFAULT_CRIT_THRESHOLD)
-                ignore_grade = bool(cfg_item.get("ignore_grade_limit", False))
-                equal_priority = bool(cfg_item.get("equal_priority", False))
-                has_custom_grade = not ignore_grade and min_grade != "A"
-                has_custom_crit = crit_value != int(DEFAULT_CRIT_THRESHOLD)
-                if stats or has_custom_grade or has_custom_crit or ignore_grade or equal_priority:
-                    self.stat_priority_configs[role] = {
-                        "stats": stats,
-                        "equal_priority": equal_priority,
-                        "ignore_grade_limit": ignore_grade,
-                        "min_grade_limit": min_grade,
-                        "crit_threshold": max(0, min(100, crit_value)),
-                    }
+                cfg = persistable_stat_priority_config(cfg_item, allowed_stats=allowed_stats)
+                if cfg:
+                    self.stat_priority_configs[role] = cfg
             self.set_effect_modes = {}
             for role, mode in data.get("set_effect_modes", {}).items():
                 normalized = normalize_set_effect_mode(mode)

--- a/src/features/allocation/role_selector.py
+++ b/src/features/allocation/role_selector.py
@@ -546,7 +546,10 @@ class RoleSelector(QWidget):
 
         row = QHBoxLayout()
         row.setSpacing(6)
-        row.addWidget(QLabel(title))
+        title_label = QLabel(title)
+        title_label.setMinimumWidth(118)
+        title_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        row.addWidget(title_label)
         combo = SearchableComboBox()
         self._fill_search_combo(combo, choices)
         row.addWidget(combo, 1)
@@ -630,15 +633,15 @@ class RoleSelector(QWidget):
         stat_layout = stat_box.layout()
         help_btn = QPushButton("?")
         help_btn.setObjectName("btnHelp")
+        help_btn.setFixedSize(24, 24)
         help_btn.clicked.connect(lambda: self._show_help("词条自选说明", STAT_PRIORITY_HELP))
 
         stat_option_row = QHBoxLayout()
-        stat_option_row.setSpacing(14)
+        stat_option_row.setContentsMargins(0, 4, 0, 0)
+        stat_option_row.setSpacing(16)
         stat_equal = QCheckBox("词条自选优先级一致")
-        stat_equal.setMinimumWidth(160)
         stat_equal.setChecked(bool(current_stat_cfg.get("equal_priority", False)))
         ignore_grade_limit = QCheckBox("不限制评分等级")
-        ignore_grade_limit.setMinimumWidth(130)
         ignore_grade_limit.setChecked(bool(current_stat_cfg.get("ignore_grade_limit", False)))
         stat_option_row.addWidget(stat_equal)
         stat_option_row.addWidget(ignore_grade_limit)
@@ -646,26 +649,28 @@ class RoleSelector(QWidget):
         stat_option_row.addStretch(1)
         stat_layout.addLayout(stat_option_row)
 
-        grade_row = QHBoxLayout()
-        grade_row.setSpacing(8)
+        limits_row = QHBoxLayout()
+        limits_row.setContentsMargins(0, 2, 0, 0)
+        limits_row.setSpacing(8)
+
         grade_label = QLabel("最低生效等级")
         grade_combo = QComboBox()
+        grade_combo.setFixedWidth(84)
         for grade in STAT_PRIORITY_GRADE_OPTIONS:
             grade_combo.addItem(grade, grade)
         current_min_grade = str(current_stat_cfg.get("min_grade_limit") or "A").upper()
         grade_index = grade_combo.findData(current_min_grade)
         grade_combo.setCurrentIndex(grade_index if grade_index >= 0 else grade_combo.findData("A"))
         grade_combo.setEnabled(not ignore_grade_limit.isChecked())
-        grade_row.addWidget(grade_label)
-        grade_row.addWidget(grade_combo, 1)
-        stat_layout.addLayout(grade_row)
+        limits_row.addWidget(grade_label)
+        limits_row.addWidget(grade_combo)
+        limits_row.addSpacing(20)
 
-        crit_row = QHBoxLayout()
-        crit_row.setSpacing(8)
-        crit_threshold_label = QLabel("暴击率阈值")
+        crit_threshold_label = QLabel("暴击率最小值")
         crit_threshold_spin = QSpinBox()
         crit_threshold_spin.setRange(0, 100)
         crit_threshold_spin.setSuffix("%")
+        crit_threshold_spin.setFixedWidth(84)
         raw_threshold = current_stat_cfg.get(
             "crit_threshold",
             current_stat_cfg.get("crit_min_threshold", DEFAULT_CRIT_THRESHOLD),
@@ -674,10 +679,10 @@ class RoleSelector(QWidget):
             crit_threshold_spin.setValue(int(raw_threshold))
         except (TypeError, ValueError):
             crit_threshold_spin.setValue(int(DEFAULT_CRIT_THRESHOLD))
-        crit_row.addWidget(crit_threshold_label)
-        crit_row.addWidget(crit_threshold_spin)
-        crit_row.addStretch(1)
-        stat_layout.addLayout(crit_row)
+        limits_row.addWidget(crit_threshold_label)
+        limits_row.addWidget(crit_threshold_spin)
+        limits_row.addStretch(1)
+        stat_layout.addLayout(limits_row)
 
         def sync_grade_combo_enabled(checked=False):
             grade_combo.setEnabled(not ignore_grade_limit.isChecked())
@@ -1005,10 +1010,10 @@ STAT_PRIORITY_HELP = (
     "关闭“优先级一致”时，按选择顺序逐层优先，例如 A > B > C 会优先使用同时含 A+B+C、再含 A+B、再含 A 的驱动。\n"
     "开启“优先级一致”时，优先使用命中副词条数量更多的驱动。\n\n"
     "未勾选“不限制评分等级”时，可通过“最低生效等级”选择 D 至 ACE 的门槛；"
-    "默认 A 级。词条自选加成与暴击率阈值加成都受该门槛约束。\n"
+    "默认 A 级。词条自选加成与暴击率最小值加成都受该门槛约束。\n"
     "勾选“不限制评分等级”后，会按整张图纸的自选副词条覆盖程度优先；覆盖相同时再比较评分。\n\n"
-    "暴击率阈值会参考当前配装的累计暴击率：低于阈值时，仅对达到最低生效等级的驱动优先选择带暴击词条的；"
-    "达到阈值后取消该加成。暴击率上限会硬性限制配装总暴击。"
+    "暴击率最小值会参考当前配装的累计暴击率：低于该值时，仅对达到最低生效等级的驱动优先选择带暴击词条的；"
+    "达到后取消该加成。暴击率上限会硬性限制配装总暴击。"
 )
 
 

--- a/src/optimizer/allocation_matrix_builder.py
+++ b/src/optimizer/allocation_matrix_builder.py
@@ -8,6 +8,17 @@ from src.optimizer.contracts import AllocationResult, CandidatePool, CustomSetMa
 
 
 class AllocationMatrixBuilder(BlueprintCandidateBuilder):
+    def _build_group_slots(self, bp_combo, valid_roles, custom_sets):
+        slots = []
+        for role_idx, role in enumerate(valid_roles):
+            bp = bp_combo[role_idx]
+            target_set = self._target_set(role, custom_sets)
+            for shape in self._set_pieces_for_blueprint(bp, target_set):
+                slots.append({"role": role, "type": "set", "shape": shape, "set_name": target_set, "bp": bp})
+            for shape in bp["extra_pieces"]:
+                slots.append({"role": role, "type": "extra", "shape": shape, "set_name": None, "bp": bp})
+        return slots
+
     def _build_profit_matrix(
         self,
         bp_combo,
@@ -18,14 +29,7 @@ class AllocationMatrixBuilder(BlueprintCandidateBuilder):
         include_extra_shape_bonus: bool = True,
     ):
         crit_priority_modes = crit_priority_modes or {}
-        slots = []
-        for role_idx, role in enumerate(valid_roles):
-            bp = bp_combo[role_idx]
-            target_set = self._target_set(role, custom_sets)
-            for shape in self._set_pieces_for_blueprint(bp, target_set):
-                slots.append({"role": role, "type": "set", "shape": shape, "set_name": target_set, "bp": bp})
-            for shape in bp["extra_pieces"]:
-                slots.append({"role": role, "type": "extra", "shape": shape, "set_name": None, "bp": bp})
+        slots = self._build_group_slots(bp_combo, valid_roles, custom_sets)
 
         if len(drives_pool) < len(slots): return None, None, None
 

--- a/src/optimizer/drive_candidate_ranker.py
+++ b/src/optimizer/drive_candidate_ranker.py
@@ -6,6 +6,8 @@ from typing import List, Dict
 
 from src.domain.crit_threshold import (
     DEFAULT_CRIT_THRESHOLD,
+    _is_crit_stat,
+    crit_floor_enabled,
     crit_rank_adjustment,
     drive_has_crit,
     loadout_crit_total,
@@ -42,32 +44,30 @@ class BaseDispatchStrategy:
             raise ValueError(f"错误：指定的套装 {raw_set} 不存在于 sets.json 中！")
         return target_set
 
-    def _stat_priority_config(self, config) -> dict:
-        normalized = normalize_preference_config(config)
-        stats = normalized.get("stats", [])
-        if not stats:
-            return {}
-        return {
-            "stats": stats,
-            "equal_priority": bool(normalized.get("equal_priority", False)),
-            "ignore_grade_limit": bool(normalized.get("ignore_grade_limit", False)),
-            "min_grade_limit": normalized.get("min_grade_limit", "A"),
-        }
-
     def _preference_config(self, config) -> dict:
         return normalize_preference_config(config)
 
+    def _stat_priority_config(self, config) -> dict:
+        """Stat-priority ranking only; empty when no preferred stats."""
+        normalized = self._preference_config(config)
+        if not normalized.get("stats"):
+            return {}
+        return normalized
+
     def _group_uses_crit_thresholds(self, group: list[str], crit_priority_modes: Dict[str, dict]) -> bool:
-        return any(preference_config_active(crit_priority_modes.get(role)) for role in group)
+        return any(crit_floor_enabled(crit_priority_modes.get(role)) for role in group)
 
     def _role_crit_context(self, role: str) -> dict:
         role_data = self.roles_db.get(role, {}) or {}
         catalog = self.stat_catalog
+        shape_areas = getattr(self, "_shape_areas", None)
+        if not isinstance(shape_areas, dict):
+            shape_areas = {}
         return {
             "role_data": role_data,
             "alias_mapping": dict(getattr(catalog, "stat_alias_mapping", {}) or {}),
             "tape_main_values": dict(getattr(catalog, "tape_main_values", {}) or {}),
-            "shape_areas": {},
+            "shape_areas": shape_areas,
         }
 
     def _current_role_crit(self, role: str, tape, drives: list[Drive]) -> float:
@@ -83,7 +83,7 @@ class BaseDispatchStrategy:
 
     def _meets_grade_limit(self, role: str, item, config) -> bool:
         cfg = self._preference_config(config)
-        if not cfg:
+        if not preference_config_active(config):
             return False
         if cfg.get("ignore_grade_limit"):
             return True
@@ -92,7 +92,7 @@ class BaseDispatchStrategy:
         return meets_min_grade(score, area, cfg.get("min_grade_limit", "A"))
 
     def _crit_rank_bonus(self, role: str, item, config, current_crit: float | None) -> float:
-        if current_crit is None or not preference_config_active(config):
+        if current_crit is None or not crit_floor_enabled(config):
             return 0.0
         if not self._meets_grade_limit(role, item, config):
             return 0.0
@@ -100,7 +100,7 @@ class BaseDispatchStrategy:
         return crit_rank_adjustment(
             current_crit,
             drive_has_crit(item),
-            pref.get("crit_threshold", pref.get("crit_min_threshold", DEFAULT_CRIT_THRESHOLD)),
+            pref.get("crit_threshold", DEFAULT_CRIT_THRESHOLD),
         )
 
     def _item_has_stat(self, item, stat_key: str) -> bool:
@@ -372,8 +372,7 @@ class BaseDispatchStrategy:
             return None
 
     def _is_crit_rate_key(self, key: str) -> bool:
-        normalized = str(key or "").replace("%", "")
-        return "暴击率" in normalized or "鏆村嚮鐜" in normalized
+        return _is_crit_stat(key)
 
     def _crit_rate_from_stats(self, stats) -> float:
         if not isinstance(stats, dict):

--- a/src/optimizer/drive_candidate_ranker.py
+++ b/src/optimizer/drive_candidate_ranker.py
@@ -6,11 +6,11 @@ from typing import List, Dict
 
 from src.domain.crit_threshold import (
     DEFAULT_CRIT_THRESHOLD,
+    character_crit_total,
     crit_floor_enabled,
     crit_rank_adjustment,
     drive_has_crit,
     is_crit_stat,
-    loadout_crit_total,
     meets_preference_grade_limit,
     normalize_preference_config,
 )
@@ -32,6 +32,17 @@ class BaseDispatchStrategy:
         self._max_single_weight_cache = {}
         self._extra_shape_factor_cache = {}
         self._extra_shape_hidden_bonus_cache = {}
+        self._my_roles_data: dict | None = None
+
+    def _character_data(self, role: str) -> dict:
+        if self._my_roles_data is None:
+            try:
+                from src.features.role.dao import load_my_roles
+
+                self._my_roles_data = load_my_roles() or {}
+            except Exception:
+                self._my_roles_data = {}
+        return self._my_roles_data.get(role, {}) or {}
 
     def _resolve_set_name(self, set_name: str) -> str:
         resolved = resolve_name(set_name, self.sets_db.keys(), cutoff=0.78)
@@ -68,7 +79,8 @@ class BaseDispatchStrategy:
 
     def _current_role_crit(self, role: str, tape, drives: list[Drive]) -> float:
         ctx = self._role_crit_context(role)
-        return loadout_crit_total(
+        return character_crit_total(
+            self._character_data(role),
             ctx["role_data"],
             tape,
             drives,

--- a/src/optimizer/drive_candidate_ranker.py
+++ b/src/optimizer/drive_candidate_ranker.py
@@ -6,13 +6,13 @@ from typing import List, Dict
 
 from src.domain.crit_threshold import (
     DEFAULT_CRIT_THRESHOLD,
-    _is_crit_stat,
     crit_floor_enabled,
     crit_rank_adjustment,
     drive_has_crit,
+    is_crit_stat,
     loadout_crit_total,
+    meets_preference_grade_limit,
     normalize_preference_config,
-    preference_config_active,
 )
 from src.domain.grade_limits import meets_min_grade
 from src.domain.stat_catalog import StatCatalog
@@ -44,12 +44,8 @@ class BaseDispatchStrategy:
             raise ValueError(f"错误：指定的套装 {raw_set} 不存在于 sets.json 中！")
         return target_set
 
-    def _preference_config(self, config) -> dict:
-        return normalize_preference_config(config)
-
     def _stat_priority_config(self, config) -> dict:
-        """Stat-priority ranking only; empty when no preferred stats."""
-        normalized = self._preference_config(config)
+        normalized = normalize_preference_config(config)
         if not normalized.get("stats"):
             return {}
         return normalized
@@ -82,21 +78,16 @@ class BaseDispatchStrategy:
         )
 
     def _meets_grade_limit(self, role: str, item, config) -> bool:
-        cfg = self._preference_config(config)
-        if not preference_config_active(config):
-            return False
-        if cfg.get("ignore_grade_limit"):
-            return True
         score = getattr(item, "role_scores", {}).get(role, 0.0)
         area = getattr(item, "area", 1) or 1
-        return meets_min_grade(score, area, cfg.get("min_grade_limit", "A"))
+        return meets_preference_grade_limit(score, area, config, require_active=True)
 
     def _crit_rank_bonus(self, role: str, item, config, current_crit: float | None) -> float:
         if current_crit is None or not crit_floor_enabled(config):
             return 0.0
         if not self._meets_grade_limit(role, item, config):
             return 0.0
-        pref = self._preference_config(config)
+        pref = normalize_preference_config(config)
         return crit_rank_adjustment(
             current_crit,
             drive_has_crit(item),
@@ -372,7 +363,7 @@ class BaseDispatchStrategy:
             return None
 
     def _is_crit_rate_key(self, key: str) -> bool:
-        return _is_crit_stat(key)
+        return is_crit_stat(key)
 
     def _crit_rate_from_stats(self, stats) -> float:
         if not isinstance(stats, dict):

--- a/src/optimizer/drive_candidate_ranker.py
+++ b/src/optimizer/drive_candidate_ranker.py
@@ -4,6 +4,15 @@ import numpy as np
 from scipy.optimize import linear_sum_assignment
 from typing import List, Dict
 
+from src.domain.crit_threshold import (
+    DEFAULT_CRIT_THRESHOLD,
+    crit_rank_adjustment,
+    drive_has_crit,
+    loadout_crit_total,
+    normalize_preference_config,
+    preference_config_active,
+)
+from src.domain.grade_limits import meets_min_grade
 from src.domain.stat_catalog import StatCatalog
 from src.models.equipment import Drive, Tape
 from src.optimizer.contracts import AllocationResult, CandidatePool, CustomSetMap, StatPriorityConfigMap
@@ -34,16 +43,65 @@ class BaseDispatchStrategy:
         return target_set
 
     def _stat_priority_config(self, config) -> dict:
-        if not isinstance(config, dict):
-            return {}
-        stats = [str(s) for s in config.get("stats", []) if s]
+        normalized = normalize_preference_config(config)
+        stats = normalized.get("stats", [])
         if not stats:
             return {}
         return {
             "stats": stats,
-            "equal_priority": bool(config.get("equal_priority", False)),
-            "ignore_grade_limit": bool(config.get("ignore_grade_limit", False)),
+            "equal_priority": bool(normalized.get("equal_priority", False)),
+            "ignore_grade_limit": bool(normalized.get("ignore_grade_limit", False)),
+            "min_grade_limit": normalized.get("min_grade_limit", "A"),
         }
+
+    def _preference_config(self, config) -> dict:
+        return normalize_preference_config(config)
+
+    def _group_uses_crit_thresholds(self, group: list[str], crit_priority_modes: Dict[str, dict]) -> bool:
+        return any(preference_config_active(crit_priority_modes.get(role)) for role in group)
+
+    def _role_crit_context(self, role: str) -> dict:
+        role_data = self.roles_db.get(role, {}) or {}
+        catalog = self.stat_catalog
+        return {
+            "role_data": role_data,
+            "alias_mapping": dict(getattr(catalog, "stat_alias_mapping", {}) or {}),
+            "tape_main_values": dict(getattr(catalog, "tape_main_values", {}) or {}),
+            "shape_areas": {},
+        }
+
+    def _current_role_crit(self, role: str, tape, drives: list[Drive]) -> float:
+        ctx = self._role_crit_context(role)
+        return loadout_crit_total(
+            ctx["role_data"],
+            tape,
+            drives,
+            alias_mapping=ctx["alias_mapping"],
+            tape_main_values=ctx["tape_main_values"],
+            shape_areas=ctx["shape_areas"],
+        )
+
+    def _meets_grade_limit(self, role: str, item, config) -> bool:
+        cfg = self._preference_config(config)
+        if not cfg:
+            return False
+        if cfg.get("ignore_grade_limit"):
+            return True
+        score = getattr(item, "role_scores", {}).get(role, 0.0)
+        area = getattr(item, "area", 1) or 1
+        return meets_min_grade(score, area, cfg.get("min_grade_limit", "A"))
+
+    def _crit_rank_bonus(self, role: str, item, config, current_crit: float | None) -> float:
+        if current_crit is None or not preference_config_active(config):
+            return 0.0
+        if not self._meets_grade_limit(role, item, config):
+            return 0.0
+        pref = self._preference_config(config)
+        return crit_rank_adjustment(
+            current_crit,
+            drive_has_crit(item),
+            pref.get("crit_threshold", pref.get("crit_min_threshold", DEFAULT_CRIT_THRESHOLD)),
+        )
 
     def _item_has_stat(self, item, stat_key: str) -> bool:
         target_raw = str(stat_key or "").strip()
@@ -191,7 +249,7 @@ class BaseDispatchStrategy:
         cfg = self._stat_priority_config(config)
         if not cfg.get("stats"):
             return False
-        return bool(cfg.get("ignore_grade_limit")) or self._is_a_grade_item(role, item)
+        return self._meets_grade_limit(role, item, config)
 
     def _stat_priority_depth(self, role: str, item, config) -> int:
         cfg = self._stat_priority_config(config)
@@ -229,6 +287,7 @@ class BaseDispatchStrategy:
         base_score: float,
         config,
         include_extra_shape_bonus: bool = True,
+        current_crit: float | None = None,
     ) -> tuple:
         rank_score = self._drive_ranking_score(
             role,
@@ -236,6 +295,7 @@ class BaseDispatchStrategy:
             base_score,
             include_extra_shape_bonus=include_extra_shape_bonus,
         )
+        rank_score += self._crit_rank_bonus(role, drive, config, current_crit)
         if self._stat_priority_enabled(config):
             return (self._stat_priority_depth(role, drive, config), rank_score)
         return (rank_score,)
@@ -257,22 +317,33 @@ class BaseDispatchStrategy:
     def _is_a_grade_item(self, role: str, item) -> bool:
         score = getattr(item, "role_scores", {}).get(role, 0.0)
         area = getattr(item, "area", 1) or 1
-        return score >= area * 10.0 * 0.4
+        return meets_min_grade(score, area, "A")
 
-    def _rank_score_for_item(self, role: str, item, base_score: float, config) -> float:
+    def _rank_score_for_item(
+        self,
+        role: str,
+        item,
+        base_score: float,
+        config,
+        current_crit: float | None = None,
+    ) -> float:
         if base_score < 0:
             return base_score
+        score = float(base_score)
         cfg = self._stat_priority_config(config)
         stats = cfg.get("stats", [])
-        if not stats or (not cfg.get("ignore_grade_limit") and not self._is_a_grade_item(role, item)):
-            return base_score
-        if cfg.get("equal_priority"):
-            covered = self._covered_stat_count(item, stats)
-            return base_score + covered * 100000.0 if covered else base_score
-        for tier, stat_key in enumerate(stats):
-            if self._item_has_stat(item, stat_key):
-                return base_score + (len(stats) - tier) * 100000.0
-        return base_score
+        if stats and self._meets_grade_limit(role, item, config):
+            if cfg.get("equal_priority"):
+                covered = self._covered_stat_count(item, stats)
+                if covered:
+                    score = base_score + covered * 100000.0
+            else:
+                for tier, stat_key in enumerate(stats):
+                    if self._item_has_stat(item, stat_key):
+                        score = base_score + (len(stats) - tier) * 100000.0
+                        break
+        score += self._crit_rank_bonus(role, item, config, current_crit)
+        return score
 
     def _rank_score_for_drive(
         self,
@@ -282,6 +353,7 @@ class BaseDispatchStrategy:
         config,
         *,
         include_extra_shape_bonus: bool = True,
+        current_crit: float | None = None,
     ) -> float:
         rank_score = self._drive_ranking_score(
             role,
@@ -289,7 +361,7 @@ class BaseDispatchStrategy:
             base_score,
             include_extra_shape_bonus=include_extra_shape_bonus,
         )
-        return self._rank_score_for_item(role, drive, rank_score, config)
+        return self._rank_score_for_item(role, drive, rank_score, config, current_crit=current_crit)
 
     def _crit_rate_cap(self, role: str, crit_rate_caps: Dict[str, float] | None):
         if not crit_rate_caps or role not in crit_rate_caps:
@@ -385,6 +457,7 @@ class BaseDispatchStrategy:
         candidates: list[tuple[int, Drive]],
         config=None,
         include_extra_shape_bonus: bool = True,
+        current_crit: float | None = None,
     ) -> tuple[int, Drive, float, float] | None:
         if not candidates:
             return None
@@ -396,14 +469,17 @@ class BaseDispatchStrategy:
                     drive.role_scores.get(role, 0.0),
                     config,
                     include_extra_shape_bonus=include_extra_shape_bonus,
+                    current_crit=current_crit,
                 ),
                 idx,
                 drive,
-                self._drive_ranking_score(
+                self._rank_score_for_drive(
                     role,
                     drive,
                     drive.role_scores.get(role, 0.0),
+                    config,
                     include_extra_shape_bonus=include_extra_shape_bonus,
+                    current_crit=current_crit,
                 ),
             )
             for idx, drive in candidates

--- a/src/optimizer/role_priority_strategy.py
+++ b/src/optimizer/role_priority_strategy.py
@@ -40,6 +40,7 @@ class RolePriorityStrategy(AllocationMatrixBuilder):
 
         used_indices = set()
         assigned_set, assigned_extra, total_score, total_rank_score = [], [], 0.0, 0.0
+        current_crit = self._current_role_crit(role_name, assigned_tape, [])
 
         set_uses_bonus = self._slot_uses_extra_shape_bonus("set", blueprint)
         for req_shape in set_shapes:
@@ -53,6 +54,7 @@ class RolePriorityStrategy(AllocationMatrixBuilder):
                 candidates,
                 crit_mode,
                 include_extra_shape_bonus=set_uses_bonus,
+                current_crit=current_crit,
             )
             if picked:
                 best_idx, best_drive, highest_score, rank_score = picked
@@ -60,6 +62,7 @@ class RolePriorityStrategy(AllocationMatrixBuilder):
                 total_score += highest_score
                 total_rank_score += rank_score
                 used_indices.add(best_idx)
+                current_crit = self._current_role_crit(role_name, assigned_tape, assigned_set + assigned_extra)
             else:
                 return {"valid": False, "score": 0.0}
 
@@ -74,6 +77,7 @@ class RolePriorityStrategy(AllocationMatrixBuilder):
                 candidates,
                 crit_mode,
                 include_extra_shape_bonus=False,
+                current_crit=current_crit,
             )
             if picked:
                 best_idx, best_drive, highest_score, rank_score = picked
@@ -81,6 +85,7 @@ class RolePriorityStrategy(AllocationMatrixBuilder):
                 total_score += highest_score
                 total_rank_score += rank_score
                 used_indices.add(best_idx)
+                current_crit = self._current_role_crit(role_name, assigned_tape, assigned_set + assigned_extra)
             else:
                 return {"valid": False, "score": 0.0}
 
@@ -330,6 +335,58 @@ class RolePriorityStrategy(AllocationMatrixBuilder):
                 improved = True
         return current
 
+    def _assign_group_slots_greedy(
+        self,
+        slots: list[dict],
+        drives_pool: list[Drive],
+        assigned_tapes: Dict[str, Tape],
+        crit_priority_modes: Dict[str, dict],
+        valid_group: list[str],
+    ):
+        used_uids: set[str] = set()
+        role_crit = {
+            role: self._current_role_crit(role, assigned_tapes.get(role), [])
+            for role in valid_group
+        }
+        temp_alloc = self._init_temp_alloc(valid_group, assigned_tapes)
+        for role in valid_group:
+            temp_alloc[role]["rank_score"] = temp_alloc[role]["score"]
+
+        for slot in slots:
+            role = slot["role"]
+            config = crit_priority_modes.get(role)
+            current_crit = role_crit.get(role, 0.0)
+            candidates = [
+                (idx, drive)
+                for idx, drive in enumerate(drives_pool)
+                if drive.uid not in used_uids and drive.shape_id == slot["shape"]
+            ]
+            slot_uses_bonus = self._slot_uses_extra_shape_bonus(slot["type"], slot.get("bp"))
+            picked = self._pick_best_drive(
+                role,
+                candidates,
+                config,
+                include_extra_shape_bonus=slot_uses_bonus,
+                current_crit=current_crit,
+            )
+            if not picked:
+                return None
+            _, drive, score, rank_score = picked
+            used_uids.add(drive.uid)
+            temp_alloc[role]["blueprint"] = slot["bp"]
+            if slot["type"] == "set":
+                temp_alloc[role]["assigned_set_drives"].append(drive)
+            else:
+                temp_alloc[role]["assigned_extra_drives"].append(drive)
+            temp_alloc[role]["score"] += score
+            temp_alloc[role]["rank_score"] += rank_score
+            role_crit[role] = self._current_role_crit(
+                role,
+                assigned_tapes.get(role),
+                temp_alloc[role]["assigned_set_drives"] + temp_alloc[role]["assigned_extra_drives"],
+            )
+        return temp_alloc
+
     def _find_best_group_fit(
         self,
         group: list[str],
@@ -353,6 +410,7 @@ class RolePriorityStrategy(AllocationMatrixBuilder):
         best_rank_score = -1.0
         best_priority_key = ()
         best_allocation = {}
+        use_greedy = self._group_uses_crit_thresholds(valid_group, crit_priority_modes)
         for bp_combo in self._iter_bp_combos(
             role_blueprints,
             valid_group,
@@ -365,6 +423,42 @@ class RolePriorityStrategy(AllocationMatrixBuilder):
             )
             if slots is None:
                 continue
+
+            if use_greedy:
+                temp_alloc = self._assign_group_slots_greedy(
+                    slots,
+                    drives_pool,
+                    assigned_tapes,
+                    crit_priority_modes,
+                    valid_group,
+                )
+                if temp_alloc is None:
+                    continue
+                is_valid = True
+                for role in valid_group:
+                    plan = temp_alloc.get(role, {})
+                    items = [
+                        plan.get("assigned_tape"),
+                        *(plan.get("assigned_set_drives", []) or []),
+                        *(plan.get("assigned_extra_drives", []) or []),
+                    ]
+                    if not self._within_crit_rate_cap(role, items, crit_rate_caps):
+                        is_valid = False
+                        break
+                if not is_valid:
+                    continue
+                team_score = sum(item["score"] for item in temp_alloc.values())
+                team_rank_score = sum(
+                    item.get("rank_score", item["score"]) for item in temp_alloc.values()
+                )
+                priority_key = self._group_stat_priority_key(temp_alloc, valid_group, crit_priority_modes)
+                if (priority_key, team_rank_score, team_score) > (best_priority_key, best_rank_score, best_score):
+                    best_priority_key = priority_key
+                    best_rank_score = team_rank_score
+                    best_score = team_score
+                    best_allocation = temp_alloc
+                continue
+
             row_ind, col_ind = linear_sum_assignment(-ranking_matrix)
             temp_alloc = self._init_temp_alloc(valid_group, assigned_tapes)
             is_valid = True

--- a/src/optimizer/role_priority_strategy.py
+++ b/src/optimizer/role_priority_strategy.py
@@ -418,13 +418,10 @@ class RolePriorityStrategy(AllocationMatrixBuilder):
             custom_sets,
             crit_priority_modes,
         ):
-            slots, profit_matrix, ranking_matrix = self._build_profit_matrix(
-                bp_combo, valid_group, drives_pool, custom_sets, crit_priority_modes
-            )
-            if slots is None:
-                continue
-
             if use_greedy:
+                slots = self._build_group_slots(bp_combo, valid_group, custom_sets)
+                if len(drives_pool) < len(slots):
+                    continue
                 temp_alloc = self._assign_group_slots_greedy(
                     slots,
                     drives_pool,
@@ -457,6 +454,12 @@ class RolePriorityStrategy(AllocationMatrixBuilder):
                     best_rank_score = team_rank_score
                     best_score = team_score
                     best_allocation = temp_alloc
+                continue
+
+            slots, profit_matrix, ranking_matrix = self._build_profit_matrix(
+                bp_combo, valid_group, drives_pool, custom_sets, crit_priority_modes
+            )
+            if slots is None:
                 continue
 
             row_ind, col_ind = linear_sum_assignment(-ranking_matrix)

--- a/src/optimizer/scoring.py
+++ b/src/optimizer/scoring.py
@@ -5,6 +5,7 @@ import json
 import os
 from typing import List, Dict, Any
 
+from src.domain.grade_limits import meets_min_grade
 from src.domain.stat_catalog import StatCatalog
 from src.utils.logger import logger
 from src.models.equipment import BaseEquipment, Drive, Tape
@@ -99,7 +100,17 @@ class ScoringEngine:
     def _is_a_grade_item(self, role: str, item: BaseEquipment) -> bool:
         score = getattr(item, "role_scores", {}).get(role, 0.0)
         area = getattr(item, "area", 1) or 1
-        return score >= area * 10.0 * 0.4
+        return meets_min_grade(score, area, "A")
+
+    def _meets_grade_limit(self, role: str, item: BaseEquipment, config: dict | None) -> bool:
+        score = getattr(item, "role_scores", {}).get(role, 0.0)
+        area = getattr(item, "area", 1) or 1
+        if isinstance(config, dict) and config.get("ignore_grade_limit"):
+            return True
+        min_grade = "A"
+        if isinstance(config, dict):
+            min_grade = str(config.get("min_grade_limit") or "A")
+        return meets_min_grade(score, area, min_grade)
 
     def _item_has_stat(self, item: BaseEquipment, stat_key: str) -> bool:
         target_raw = str(stat_key or "").strip()
@@ -116,7 +127,7 @@ class ScoringEngine:
     def _priority_rank_for_item(self, role: str, item: BaseEquipment, config: dict | None) -> tuple[int, int]:
         if not isinstance(config, dict):
             return (0, 0)
-        if not config.get("ignore_grade_limit") and not self._is_a_grade_item(role, item):
+        if not self._meets_grade_limit(role, item, config):
             return (0, 0)
         stats = [str(stat) for stat in config.get("stats", []) if stat]
         if not stats:

--- a/src/optimizer/scoring.py
+++ b/src/optimizer/scoring.py
@@ -5,6 +5,7 @@ import json
 import os
 from typing import List, Dict, Any
 
+from src.domain.crit_threshold import meets_preference_grade_limit
 from src.domain.grade_limits import meets_min_grade
 from src.domain.stat_catalog import StatCatalog
 from src.utils.logger import logger
@@ -102,15 +103,6 @@ class ScoringEngine:
         area = getattr(item, "area", 1) or 1
         return meets_min_grade(score, area, "A")
 
-    def _meets_grade_limit(self, role: str, item: BaseEquipment, config: dict | None) -> bool:
-        score = getattr(item, "role_scores", {}).get(role, 0.0)
-        area = getattr(item, "area", 1) or 1
-        if isinstance(config, dict) and config.get("ignore_grade_limit"):
-            return True
-        min_grade = "A"
-        if isinstance(config, dict):
-            min_grade = str(config.get("min_grade_limit") or "A")
-        return meets_min_grade(score, area, min_grade)
 
     def _item_has_stat(self, item: BaseEquipment, stat_key: str) -> bool:
         target_raw = str(stat_key or "").strip()
@@ -127,7 +119,9 @@ class ScoringEngine:
     def _priority_rank_for_item(self, role: str, item: BaseEquipment, config: dict | None) -> tuple[int, int]:
         if not isinstance(config, dict):
             return (0, 0)
-        if not self._meets_grade_limit(role, item, config):
+        score = getattr(item, "role_scores", {}).get(role, 0.0)
+        area = getattr(item, "area", 1) or 1
+        if not meets_preference_grade_limit(score, area, config):
             return (0, 0)
         stats = [str(stat) for stat in config.get("stats", []) if stat]
         if not stats:

--- a/tests/test_crit_threshold.py
+++ b/tests/test_crit_threshold.py
@@ -4,6 +4,8 @@ import unittest
 from src.domain.crit_threshold import (
     CRIT_RANK_BONUS,
     DEFAULT_CRIT_THRESHOLD,
+    character_crit_baseline,
+    character_crit_total,
     crit_floor_enabled,
     crit_rank_adjustment,
     drive_has_crit,
@@ -66,6 +68,24 @@ class CritThresholdDomainTests(unittest.TestCase):
         total = loadout_crit_total(role_data, tape, drives, tape_main_values={"攻击力%": 37.5})
         # tape 10 + drives 3+1 + extra buff 2 * one matching 3-cell drive
         self.assertAlmostEqual(16.0, total)
+
+    def test_character_crit_baseline_ignores_weapon_skill(self):
+        character = {
+            "sub_stats": {"暴击率%": 5.0},
+            "weapon": {
+                "sub_stats": {"暴击率%": 24.0},
+                "skill": [{"key": "暴击率%", "value": 50.0, "cover": 1.0}],
+            },
+        }
+        self.assertAlmostEqual(29.0, character_crit_baseline(character))
+
+    def test_character_crit_total_includes_baseline_and_loadout(self):
+        character = {"sub_stats": {"暴击率%": 5.0}, "weapon": {"sub_stats": {"暴击率%": 24.0}}}
+        role_data = {"extra_shape_label": "", "extra_shape_buffs": {}}
+        tape = {"main_stats": "攻击力%", "sub_stats": {"暴击率%": 10.0}, "quality": "Gold"}
+        drives = [{"shape_id": "H_2", "area": 2, "sub_stats": {"暴击率%": 3.0}}]
+        total = character_crit_total(character, role_data, tape, drives, tape_main_values={"攻击力%": 37.5})
+        self.assertAlmostEqual(42.0, total)
 
     def test_meets_min_grade_boundaries(self):
         # area 3 => max 30; A requires >= 0.4 => 12

--- a/tests/test_crit_threshold.py
+++ b/tests/test_crit_threshold.py
@@ -1,0 +1,74 @@
+# 暴击阈值与等级门槛 domain 测试。
+import unittest
+
+from src.domain.crit_threshold import (
+    CRIT_RANK_BONUS,
+    DEFAULT_CRIT_THRESHOLD,
+    crit_floor_enabled,
+    crit_rank_adjustment,
+    drive_has_crit,
+    loadout_crit_total,
+    normalize_preference_config,
+    preference_config_active,
+)
+from src.domain.grade_limits import meets_min_grade
+
+
+class CritThresholdDomainTests(unittest.TestCase):
+    def test_default_crit_threshold_is_five(self):
+        self.assertEqual(5.0, DEFAULT_CRIT_THRESHOLD)
+        normalized = normalize_preference_config({"stats": ["攻击力%"]})
+        self.assertEqual(5.0, normalized["crit_threshold"])
+
+    def test_normalize_keeps_legacy_crit_min_threshold(self):
+        normalized = normalize_preference_config({"stats": ["暴击率%"], "crit_min_threshold": 18})
+        self.assertEqual(18.0, normalized["crit_threshold"])
+
+    def test_preference_config_active_ignores_empty(self):
+        self.assertFalse(preference_config_active(None))
+        self.assertFalse(preference_config_active({}))
+        self.assertTrue(preference_config_active({"stats": ["攻击力%"]}))
+        self.assertTrue(preference_config_active({"min_grade_limit": "S"}))
+        self.assertTrue(preference_config_active({"crit_threshold": 5}))
+
+    def test_crit_floor_requires_explicit_threshold_key(self):
+        self.assertFalse(crit_floor_enabled(None))
+        self.assertFalse(crit_floor_enabled({}))
+        self.assertFalse(crit_floor_enabled({"stats": ["攻击力%"]}))
+        self.assertFalse(crit_floor_enabled({"min_grade_limit": "S"}))
+        self.assertTrue(crit_floor_enabled({"crit_threshold": 5}))
+        self.assertTrue(crit_floor_enabled({"stats": ["攻击力%"], "crit_threshold": 5}))
+        self.assertTrue(crit_floor_enabled({"crit_min_threshold": 12}))
+
+    def test_crit_rank_adjustment_only_below_threshold(self):
+        self.assertEqual(CRIT_RANK_BONUS, crit_rank_adjustment(3.0, True, 5.0))
+        self.assertEqual(0.0, crit_rank_adjustment(5.0, True, 5.0))
+        self.assertEqual(0.0, crit_rank_adjustment(1.0, False, 5.0))
+
+    def test_drive_has_crit(self):
+        self.assertTrue(drive_has_crit({"sub_stats": {"暴击率%": 3.0}}))
+        self.assertFalse(drive_has_crit({"sub_stats": {"攻击力%": 3.0}}))
+
+    def test_loadout_crit_total_sums_tape_drives_and_extra_buff(self):
+        role_data = {
+            "extra_shape_label": "3格",
+            "extra_shape_buffs": {"暴击率%": 2.0, "攻击力%": 10.0},
+        }
+        tape = {"main_stats": "攻击力%", "sub_stats": {"暴击率%": 10.0}, "quality": "Gold"}
+        drives = [
+            {"shape_id": "V_3", "area": 3, "sub_stats": {"暴击率%": 3.0}},
+            {"shape_id": "H_2", "area": 2, "sub_stats": {"暴击率%": 1.0}},
+        ]
+        total = loadout_crit_total(role_data, tape, drives, tape_main_values={"攻击力%": 37.5})
+        # tape 10 + drives 3+1 + extra buff 2 * one matching 3-cell drive
+        self.assertAlmostEqual(16.0, total)
+
+    def test_meets_min_grade_boundaries(self):
+        # area 3 => max 30; A requires >= 0.4 => 12
+        self.assertTrue(meets_min_grade(12.0, 3, "A"))
+        self.assertFalse(meets_min_grade(11.9, 3, "A"))
+        self.assertTrue(meets_min_grade(0.0, 3, "D"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_crit_threshold.py
+++ b/tests/test_crit_threshold.py
@@ -8,10 +8,14 @@ from src.domain.crit_threshold import (
     crit_rank_adjustment,
     drive_has_crit,
     loadout_crit_total,
+    meets_preference_grade_limit,
     normalize_preference_config,
+    persistable_stat_priority_config,
     preference_config_active,
 )
 from src.domain.grade_limits import meets_min_grade
+
+ALLOWED = frozenset({"攻击力%", "暴击率%", "Crit"})
 
 
 class CritThresholdDomainTests(unittest.TestCase):
@@ -68,6 +72,189 @@ class CritThresholdDomainTests(unittest.TestCase):
         self.assertTrue(meets_min_grade(12.0, 3, "A"))
         self.assertFalse(meets_min_grade(11.9, 3, "A"))
         self.assertTrue(meets_min_grade(0.0, 3, "D"))
+
+    def test_persistable_stat_priority_config(self):
+        self.assertIsNone(persistable_stat_priority_config({"crit_threshold": 5}))
+        cfg = persistable_stat_priority_config({"stats": ["攻击力%"], "crit_threshold": 5})
+        self.assertEqual(["攻击力%"], cfg["stats"])
+        self.assertEqual(5, cfg["crit_threshold"])
+        self.assertIsNone(
+            persistable_stat_priority_config(
+                {"stats": ["未知%"]},
+                allowed_stats={"攻击力%"},
+            )
+        )
+
+    def test_persistable_ui_save(self):
+        cases = [
+            (
+                {
+                    "stats": ["攻击力%"],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 5,
+                },
+                {
+                    "stats": ["攻击力%"],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 5,
+                },
+            ),
+            (
+                {
+                    "stats": ["攻击力%", "攻击力%"],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 5,
+                },
+                {
+                    "stats": ["攻击力%"],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 5,
+                },
+            ),
+            (
+                {
+                    "stats": [],
+                    "equal_priority": True,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 5,
+                },
+                {
+                    "stats": [],
+                    "equal_priority": True,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 5,
+                },
+            ),
+            (
+                {
+                    "stats": [],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "S",
+                    "crit_threshold": 5,
+                },
+                {
+                    "stats": [],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "S",
+                    "crit_threshold": 5,
+                },
+            ),
+            (
+                {
+                    "stats": [],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 20,
+                },
+                {
+                    "stats": [],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 20,
+                },
+            ),
+            (
+                {
+                    "stats": ["未知%"],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 5,
+                },
+                None,
+            ),
+            (
+                {
+                    "stats": [],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 5,
+                },
+                None,
+            ),
+        ]
+        for raw, expected in cases:
+            with self.subTest(raw=raw):
+                self.assertEqual(
+                    expected,
+                    persistable_stat_priority_config(raw, allowed_stats=ALLOWED, dedupe_stats=True),
+                )
+
+    def test_persistable_import(self):
+        cases = [
+            (
+                {"stats": ["攻击力%"]},
+                {
+                    "stats": ["攻击力%"],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 5,
+                },
+            ),
+            (
+                {"stats": ["攻击力%", "攻击力%"]},
+                {
+                    "stats": ["攻击力%", "攻击力%"],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 5,
+                },
+            ),
+            (
+                {"stats": ["攻击力%"], "crit_min_threshold": 18},
+                {
+                    "stats": ["攻击力%"],
+                    "equal_priority": False,
+                    "ignore_grade_limit": False,
+                    "min_grade_limit": "A",
+                    "crit_threshold": 18,
+                },
+            ),
+            ({"crit_threshold": 5}, None),
+            ({"stats": ["未知%"]}, None),
+        ]
+        for raw, expected in cases:
+            with self.subTest(raw=raw):
+                self.assertEqual(
+                    expected,
+                    persistable_stat_priority_config(raw, allowed_stats=ALLOWED),
+                )
+
+    def test_meets_preference_grade_limit(self):
+        cases = [
+            ((12.0, 3, None, False), True),
+            ((12.0, 3, {}, False), True),
+            ((11.9, 3, {"stats": ["攻击力%"]}, False), False),
+            ((0.0, 3, {"ignore_grade_limit": True}, False), True),
+            ((0.0, 3, {"min_grade_limit": "S"}, False), False),
+            ((18.0, 3, {"min_grade_limit": "S"}, False), True),
+            ((12.0, 3, {"stats": ["攻击力%"]}, True), True),
+            ((12.0, 3, {}, True), False),
+            ((12.0, 3, {"crit_threshold": 5}, True), True),
+        ]
+        for (score, area, config, require_active), expected in cases:
+            with self.subTest(score=score, config=config, require_active=require_active):
+                self.assertEqual(
+                    expected,
+                    meets_preference_grade_limit(score, area, config, require_active=require_active),
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- 词条自选增加「最低生效等级」「暴击率最小值」，写入 stat_priority_configs
- 抽出 grade_limits / crit_threshold，供 UI 与 role_priority 共用
- 暴击未达最小值时，对达标等级且带暴击词条的驱动加隐藏分；多人组改为 greedy 滚动累计暴击
- 默认最小值与多人组算法切换的触发条件

## Test plan
- [x] 单人：暴击低于/高于最小值时选件变化
- [x] 等级门槛 D–ACE / 「不限制评分等级」交互正确
- [x] 多人组 + 词条自选结果可接受
- [x] 与暴击上限同时开启时无矛盾
- [x] 旧配置无 crit_threshold 键能加载；保存后再读完整
- [x] 驱动优先/全局最优仍忽略这些偏好